### PR TITLE
Removing node step from build definition

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,9 +71,6 @@ jobs:
       steps:
       - checkout: self
         clean: true
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '10.x'
       - task: NuGetCommand@2
         displayName: 'Clear NuGet caches'
         condition: succeeded()


### PR DESCRIPTION
That was left over from the build definition we pulled in from the AspLabs repo.