### PR TITLE
Removing ICommand.GetHelpSummary and all of its implementations

### DIFF
--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -498,11 +498,6 @@ namespace Microsoft.HttpRepl.Commands
             return helpText.ToString();
         }
 
-        public override string GetHelpSummary(IShellState shellState, HttpState programState)
-        {
-            return $"{Verb.ToLowerInvariant()} - Issues a {Verb.ToUpperInvariant()} request";
-        }
-
         protected override IEnumerable<string> GetArgumentSuggestionsForText(IShellState shellState, HttpState programState, ICoreParseResult parseResult, DefaultCommandInput<ICoreParseResult> commandInput, string normalCompletionString)
         {
             List<string> results = new List<string>();

--- a/src/Microsoft.HttpRepl/Commands/ChangeDirectoryCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ChangeDirectoryCommand.cs
@@ -77,11 +77,6 @@ namespace Microsoft.HttpRepl.Commands
             return help.ToString();
         }
 
-        public override string GetHelpSummary(IShellState shellState, HttpState programState)
-        {
-            return "cd [directory name] - Prints the current directory if no argument is specified, otherwise changes to the specified directory";
-        }
-
         protected override IEnumerable<string> GetArgumentSuggestionsForText(IShellState shellState, HttpState programState, ICoreParseResult parseResult, DefaultCommandInput<ICoreParseResult> commandInput, string normalCompletionString)
         {
             return ServerPathCompletion.GetCompletions(programState, normalCompletionString);

--- a/src/Microsoft.HttpRepl/Commands/ClearCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ClearCommand.cs
@@ -40,11 +40,6 @@ namespace Microsoft.HttpRepl.Commands
             return null;
         }
 
-        public string GetHelpSummary(IShellState shellState, object programState)
-        {
-            return "clear - Clears the shell";
-        }
-
         public IEnumerable<string> Suggest(IShellState shellState, object programState, ICoreParseResult parseResult)
         {
             if (parseResult.SelectedSection == 0 && 

--- a/src/Microsoft.HttpRepl/Commands/ConfigCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ConfigCommand.cs
@@ -61,10 +61,5 @@ namespace Microsoft.HttpRepl.Commands
         {
             return "config - Gets configuration information for the site if connected to a diagnostics endpoint";
         }
-
-        public override string GetHelpSummary(IShellState shellState, HttpState programState)
-        {
-            return "config - Gets configuration information for the site if connected to a diagnostics endpoint";
-        }
     }
 }

--- a/src/Microsoft.HttpRepl/Commands/EchoCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/EchoCommand.cs
@@ -50,11 +50,6 @@ namespace Microsoft.HttpRepl.Commands
             return helpText.ToString();
         }
 
-        public override string GetHelpSummary(IShellState shellState, HttpState programState)
-        {
-            return "echo [on/off] - Turns request echoing on or off";
-        }
-
         protected override IEnumerable<string> GetArgumentSuggestionsForText(IShellState shellState, HttpState programState, ICoreParseResult parseResult, DefaultCommandInput<ICoreParseResult> commandInput, string normalCompletionString)
         {
             List<string> result = _allowedModes.Where(x => x.StartsWith(normalCompletionString, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/Microsoft.HttpRepl/Commands/ExitCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ExitCommand.cs
@@ -30,10 +30,5 @@ namespace Microsoft.HttpRepl.Commands
             helpText.AppendLine($"Exits the shell");
             return helpText.ToString();
         }
-
-        public override string GetHelpSummary(IShellState shellState, object programState)
-        {
-            return "exit - Exits the shell";
-        }
     }
 }

--- a/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
@@ -163,11 +163,6 @@ namespace Microsoft.HttpRepl.Commands
             return null;
         }
 
-        public string GetHelpSummary(IShellState shellState, HttpState programState)
-        {
-            return "help - Gets help";
-        }
-
         public IEnumerable<string> Suggest(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
             if (parseResult.SelectedSection == 0 &&

--- a/src/Microsoft.HttpRepl/Commands/ListCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ListCommand.cs
@@ -135,11 +135,6 @@ namespace Microsoft.HttpRepl.Commands
             return helpText.ToString();
         }
 
-        public override string GetHelpSummary(IShellState shellState, HttpState programState)
-        {
-            return "ls - List known routes for the current location";
-        }
-
         protected override IEnumerable<string> GetArgumentSuggestionsForText(IShellState shellState, HttpState programState, ICoreParseResult parseResult, DefaultCommandInput<ICoreParseResult> commandInput, string normalCompletionString)
         {
             if (programState.Structure == null || programState.BaseAddress == null)

--- a/src/Microsoft.HttpRepl/Commands/PrefCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/PrefCommand.cs
@@ -22,11 +22,6 @@ namespace Microsoft.HttpRepl.Commands
         private const string _SetCommandSyntax = "pref set {setting} [{value}]";
         private readonly HashSet<string> _allowedSubcommands = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {"get", "set"};
 
-        public override string GetHelpSummary(IShellState shellState, HttpState programState)
-        {
-            return string.Format(Resources.Strings.PrefCommand_HelpSummary, _CommandSyntax);
-        }
-
         protected override bool CanHandle(IShellState shellState, HttpState programState, DefaultCommandInput<ICoreParseResult> commandInput)
         {
             if (commandInput.Arguments.Count == 0 || !_allowedSubcommands.Contains(commandInput.Arguments[0]?.Text))

--- a/src/Microsoft.HttpRepl/Commands/RunCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/RunCommand.cs
@@ -68,11 +68,6 @@ namespace Microsoft.HttpRepl.Commands
             return null;
         }
 
-        public string GetHelpSummary(IShellState shellState, HttpState programState)
-        {
-            return "run {path to script} - Runs a script";
-        }
-
         public IEnumerable<string> Suggest(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
             if (parseResult.SelectedSection == 0 &&

--- a/src/Microsoft.HttpRepl/Commands/SetBaseCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/SetBaseCommand.cs
@@ -107,11 +107,6 @@ namespace Microsoft.HttpRepl.Commands
             return null;
         }
 
-        public string GetHelpSummary(IShellState shellState, HttpState programState)
-        {
-            return Description;
-        }
-
         public IEnumerable<string> Suggest(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
             if (parseResult.Sections.Count == 0)

--- a/src/Microsoft.HttpRepl/Commands/SetDiagCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/SetDiagCommand.cs
@@ -103,11 +103,6 @@ namespace Microsoft.HttpRepl.Commands
             }
         }
 
-        public string GetHelpSummary(IShellState shellState, HttpState programState)
-        {
-            return Description;
-        }
-
         public string GetHelpDetails(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
             if (parseResult.Sections.Count > 1 && string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase) && string.Equals(parseResult.Sections[1], SubCommand, StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.HttpRepl/Commands/SetHeaderCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/SetHeaderCommand.cs
@@ -53,11 +53,6 @@ namespace Microsoft.HttpRepl.Commands
             return Description;
         }
 
-        public string GetHelpSummary(IShellState shellState, HttpState programState)
-        {
-            return Description;
-        }
-
         public IEnumerable<string> Suggest(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
             if (parseResult.Sections.Count == 0)

--- a/src/Microsoft.HttpRepl/Commands/SetSwaggerCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/SetSwaggerCommand.cs
@@ -191,11 +191,6 @@ namespace Microsoft.HttpRepl.Commands
             return reader.Read(responseObject);
         }
 
-        public string GetHelpSummary(IShellState shellState, HttpState programState)
-        {
-            return Description;
-        }
-
         public string GetHelpDetails(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
             if (parseResult.Sections.Count > 1 && string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase) && string.Equals(parseResult.Sections[1], SubCommand, StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.HttpRepl/Commands/UICommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/UICommand.cs
@@ -62,11 +62,6 @@ namespace Microsoft.HttpRepl.Commands
             return null;
         }
 
-        public string GetHelpSummary(IShellState shellState, HttpState programState)
-        {
-            return "ui - Launches the Swagger UI page (if available) in the default browser";
-        }
-
         public IEnumerable<string> Suggest(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
             if (parseResult.SelectedSection == 0 &&

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -221,14 +221,5 @@ namespace Microsoft.HttpRepl.Resources {
                 return ResourceManager.GetString("PrefCommand_HelpDetails_Syntax", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} - Allows viewing or changing preferences.
-        /// </summary>
-        internal static string PrefCommand_HelpSummary {
-            get {
-                return ResourceManager.GetString("PrefCommand_HelpSummary", resourceCulture);
-            }
-        }
     }
 }

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -179,8 +179,4 @@
     <value>{0} - Get or sets a preference to a particular value</value>
     <comment>{0} is the overall command syntax</comment>
   </data>
-  <data name="PrefCommand_HelpSummary" xml:space="preserve">
-    <value>{0} - Allows viewing or changing preferences</value>
-    <comment>{0} is the command text</comment>
-  </data>
 </root>

--- a/src/Microsoft.Repl.Tests/Mocks/MockCommand.cs
+++ b/src/Microsoft.Repl.Tests/Mocks/MockCommand.cs
@@ -30,11 +30,6 @@ namespace Microsoft.Repl.Tests.Mocks
             return null;
         }
 
-        public string GetHelpSummary(IShellState shellState, object programState)
-        {
-            return null;
-        }
-
         public IEnumerable<string> Suggest(IShellState shellState, object programState, ICoreParseResult parseResult)
         {
             return new[] { _commandName };

--- a/src/Microsoft.Repl/Commanding/CommandWithStructuredInputBase.cs
+++ b/src/Microsoft.Repl/Commanding/CommandWithStructuredInputBase.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Repl.Commanding
     public abstract class CommandWithStructuredInputBase<TProgramState, TParseResult> : ICommand<TProgramState, TParseResult>
         where TParseResult : ICoreParseResult
     {
-        public abstract string GetHelpSummary(IShellState shellState, TProgramState programState);
-
         public string GetHelpDetails(IShellState shellState, TProgramState programState, TParseResult parseResult)
         {
             if (!DefaultCommandInput<TParseResult>.TryProcess(InputSpec, parseResult, out DefaultCommandInput<TParseResult> commandInput, out IReadOnlyList<CommandInputProcessingIssue> processingIssues) 

--- a/src/Microsoft.Repl/Commanding/ICommand.cs
+++ b/src/Microsoft.Repl/Commanding/ICommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -11,8 +11,6 @@ namespace Microsoft.Repl.Commanding
     public interface ICommand<in TProgramState, in TParseResult>
         where TParseResult : ICoreParseResult
     {
-        string GetHelpSummary(IShellState shellState, TProgramState programState);
-
         string GetHelpDetails(IShellState shellState, TProgramState programState, TParseResult parseResult);
 
         IEnumerable<string> Suggest(IShellState shellState, TProgramState programState, TParseResult parseResult);


### PR DESCRIPTION
Fixes #43 - ICommand.GetHelpSummary, and all of its implementations are never called. In many cases, it's just a duplicate of GetHelpDetails anyway.