### PR TITLE
Rework preferences

### DIFF
--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/DeleteCommandsTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/DeleteCommandsTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using Microsoft.HttpRepl.Commands;
 using Microsoft.HttpRepl.FileSystem;
@@ -14,7 +17,7 @@ namespace Microsoft.HttpRepl.IntegrationTests.Commands
         private readonly DeleteCommandsConfig _config;
         
         public DeleteCommandTests(HttpCommandsFixture<DeleteCommandsConfig> deleteCommandsFixture)
-            : base(new DeleteCommand(_fileSystem))
+            : base(new DeleteCommand(_fileSystem, new NullPreferences()))
         {
             _config = deleteCommandsFixture.Config;
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/GetCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/GetCommandTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using Microsoft.HttpRepl.Commands;
 using Microsoft.HttpRepl.IntegrationTests.Mocks;
@@ -10,7 +13,7 @@ namespace Microsoft.HttpRepl.IntegrationTests.Commands
     {
         private readonly GetCommandsConfig _config;
         public GetCommandTests(HttpCommandsFixture<GetCommandsConfig> getCommandsFixture)
-            : base(new GetCommand(new MockedFileSystem()))
+            : base(new GetCommand(new MockedFileSystem(), new NullPreferences()))
         {
             _config = getCommandsFixture.Config;
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/HeadCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/HeadCommandTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using Microsoft.HttpRepl.Commands;
 using Microsoft.HttpRepl.IntegrationTests.Mocks;
@@ -10,7 +13,7 @@ namespace Microsoft.HttpRepl.IntegrationTests.Commands
     {
         private readonly HeadCommandsConfig _config;
         public HeadCommandTests(HttpCommandsFixture<HeadCommandsConfig> headCommandsFixture)
-            :  base(new HeadCommand(new MockedFileSystem()))
+            :  base(new HeadCommand(new MockedFileSystem(), new NullPreferences()))
         {
             _config = headCommandsFixture.Config;
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/HttpCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/HttpCommandTests.cs
@@ -1,9 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.HttpRepl.Commands;
 using Microsoft.HttpRepl.FileSystem;
 using Microsoft.HttpRepl.IntegrationTests.Mocks;
+using Microsoft.HttpRepl.IntegrationTests.Preferences;
 using Microsoft.HttpRepl.Preferences;
 using Microsoft.HttpRepl.UserProfile;
 using Microsoft.Repl.ConsoleHandling;
@@ -21,7 +25,7 @@ namespace Microsoft.HttpRepl.IntegrationTests.Commands
         public HttpCommandTests(T command)
         {
             _command = command;
-            _preferences = new HttpRepl.Preferences.UserFolderPreferences(FileSystem, new UserProfileDirectoryProvider());
+            _preferences = new UserFolderPreferences(FileSystem, new UserProfileDirectoryProvider(), TestDefaultPreferences.GetDefaultPreferences());
         }
 
         protected async Task VerifyErrorMessage(string commandText, string baseAddress, string path, string expectedErrorMessage)

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/OptionsCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/OptionsCommandTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 using Microsoft.HttpRepl.Commands;
 using Microsoft.HttpRepl.IntegrationTests.Mocks;
@@ -10,7 +13,7 @@ namespace Microsoft.HttpRepl.IntegrationTests.Commands
     {
         private readonly OptionsCommandsConfig _config;
         public OptionsCommandTests(HttpCommandsFixture<OptionsCommandsConfig> optionsCommandsFixture)
-            : base(new OptionsCommand(new MockedFileSystem()))
+            : base(new OptionsCommand(new MockedFileSystem(), new NullPreferences()))
         {
             _config = optionsCommandsFixture.Config;
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/PatchCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/PatchCommandTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -15,7 +18,7 @@ namespace Microsoft.HttpRepl.IntegrationTests.Commands
 
         private readonly PatchCommandsConfig _config;
         public PatchCommandTests(HttpCommandsFixture<PatchCommandsConfig> PatchCommandsFixture)
-            : base(new PatchCommand(_fileSystem))
+            : base(new PatchCommand(_fileSystem, new NullPreferences()))
         {
             _config = PatchCommandsFixture.Config;
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/PostCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/PostCommandTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -15,7 +18,7 @@ namespace Microsoft.HttpRepl.IntegrationTests.Commands
 
         private readonly PostCommandsConfig _config;
         public PostCommandTests(HttpCommandsFixture<PostCommandsConfig> postCommandsFixture)
-            : base(new PostCommand(_fileSystem))
+            : base(new PostCommand(_fileSystem, new NullPreferences()))
         {
             _config = postCommandsFixture.Config;
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/PutCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/PutCommandTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -15,7 +18,7 @@ namespace Microsoft.HttpRepl.IntegrationTests.Commands
 
         private readonly PutCommandsConfig _config;
         public PutCommandTests(HttpCommandsFixture<PutCommandsConfig> PutCommandsFixture)
-            : base(new PutCommand(_fileSystem))
+            : base(new PutCommand(_fileSystem, new NullPreferences()))
         {
             _config = PutCommandsFixture.Config;
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/Mocks/NullPreferences.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Mocks/NullPreferences.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.HttpRepl.Preferences;
+using Microsoft.Repl.ConsoleHandling;
+
+namespace Microsoft.HttpRepl.IntegrationTests.Mocks
+{
+    public class NullPreferences : IPreferences
+    {
+        public IReadOnlyDictionary<string, string> CurrentPreferences => null;
+        public IReadOnlyDictionary<string, string> DefaultPreferences => null;
+
+        public AllowedColors GetColorValue(string preference, AllowedColors defaultValue = AllowedColors.None)
+        {
+            return defaultValue;
+        }
+
+        public int GetIntValue(string preference, int defaultValue = 0)
+        {
+            return defaultValue;
+        }
+
+        public string GetValue(string preference, string defaultValue = null)
+        {
+            return defaultValue;
+        }
+
+        public bool SetValue(string preference, string value)
+        {
+            return false;
+        }
+
+        public bool TryGetValue(string preference, out string value)
+        {
+            value = null;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.HttpRepl.IntegrationTests/Preferences/TestDefaultPreferences.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Preferences/TestDefaultPreferences.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.HttpRepl.IntegrationTests.Preferences
+{
+    internal static class TestDefaultPreferences
+    {
+        internal static Dictionary<string, string> GetDefaultPreferences()
+        {
+            // For now, we'll just use the same defaults as used by the app.
+            return Program.CreateDefaultPreferences();
+        }
+    }
+}

--- a/src/Microsoft.HttpRepl.IntegrationTests/Preferences/UserFolderPreferencesTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Preferences/UserFolderPreferencesTests.cs
@@ -63,9 +63,13 @@ This third line is invalid as well";
 
             // Add one and change one
             // Only the changes should be written, not any of the defaults.
-            preferences.SetValue(WellKnownPreference.DefaultEditorCommand, defaultEditor);
-            preferences.SetValue(WellKnownPreference.ErrorColor, errorColor);
+            bool succeeded = preferences.SetValue(WellKnownPreference.DefaultEditorCommand, defaultEditor);
 
+            Assert.True(succeeded);
+
+            succeeded = preferences.SetValue(WellKnownPreference.ErrorColor, errorColor);
+
+            Assert.True(succeeded);
             Assert.Equal(expected, fileSystem.ReadFile(preferences.PreferencesFilePath));
         }
 
@@ -88,8 +92,9 @@ This third line is invalid as well";
 
             // Now change it to the default value, write it back to the file system and
             // validate that it was removed from the file
-            preferences.SetValue(WellKnownPreference.ProtocolColor, defaultPreferences[WellKnownPreference.ProtocolColor]);
-            
+            bool succeeded = preferences.SetValue(WellKnownPreference.ProtocolColor, defaultPreferences[WellKnownPreference.ProtocolColor]);
+
+            Assert.True(succeeded);
             Assert.Equal(string.Empty, fileSystem.ReadFile(preferences.PreferencesFilePath));
         }
 

--- a/src/Microsoft.HttpRepl/Commands/DeleteCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/DeleteCommand.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.HttpRepl.FileSystem;
+using Microsoft.HttpRepl.Preferences;
 
 namespace Microsoft.HttpRepl.Commands
 {
     public class DeleteCommand : BaseHttpCommand
     {
-        public DeleteCommand(IFileSystem fileSystem) : base(fileSystem) { }
+        public DeleteCommand(IFileSystem fileSystem, IPreferences preferences) : base(fileSystem, preferences) { }
 
         protected override string Verb => "delete";
 

--- a/src/Microsoft.HttpRepl/Commands/GetCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/GetCommand.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.HttpRepl.FileSystem;
+using Microsoft.HttpRepl.Preferences;
 
 namespace Microsoft.HttpRepl.Commands
 {
     public class GetCommand : BaseHttpCommand
     {
-        public GetCommand(IFileSystem fileSystem) : base(fileSystem) { }
+        public GetCommand(IFileSystem fileSystem, IPreferences preferences) : base(fileSystem, preferences) { }
 
         protected override string Verb => "get";
 

--- a/src/Microsoft.HttpRepl/Commands/HeadCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/HeadCommand.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.HttpRepl.FileSystem;
+using Microsoft.HttpRepl.Preferences;
 
 namespace Microsoft.HttpRepl.Commands
 {
     public class HeadCommand : BaseHttpCommand
     {
-        public HeadCommand(IFileSystem fileSystem) : base(fileSystem) { }
+        public HeadCommand(IFileSystem fileSystem, IPreferences preferences) : base(fileSystem, preferences) { }
 
         protected override string Verb => "head";
 

--- a/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
@@ -20,6 +20,13 @@ namespace Microsoft.HttpRepl.Commands
     {
         private static readonly string Name = "help";
 
+        private readonly IPreferences _preferences;
+
+        public HelpCommand(IPreferences preferences)
+        {
+            _preferences = preferences;
+        }
+
         public bool? CanHandle(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
             return parseResult.Sections.Count > 0 && string.Equals(parseResult.Sections[0], Name)
@@ -85,7 +92,7 @@ namespace Microsoft.HttpRepl.Commands
 
                             if (programState.SwaggerEndpoint != null)
                             {
-                                string swaggerRequeryBehaviorSetting = programState.GetStringPreference(WellKnownPreference.SwaggerRequeryBehavior, "auto");
+                                string swaggerRequeryBehaviorSetting = _preferences.GetValue(WellKnownPreference.SwaggerRequeryBehavior, "auto");
 
                                 if (swaggerRequeryBehaviorSetting.StartsWith("auto", StringComparison.OrdinalIgnoreCase))
                                 {

--- a/src/Microsoft.HttpRepl/Commands/ListCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ListCommand.cs
@@ -20,11 +20,19 @@ namespace Microsoft.HttpRepl.Commands
     {
         private const string RecursiveOption = nameof(RecursiveOption);
 
+        private readonly IPreferences _preferences;
+
+        public ListCommand(IPreferences preferences)
+        {
+            _preferences = preferences;
+        }
+
+
         protected override async Task ExecuteAsync(IShellState shellState, HttpState programState, DefaultCommandInput<ICoreParseResult> commandInput, ICoreParseResult parseResult, CancellationToken cancellationToken)
         {
             if (programState.SwaggerEndpoint != null)
             {
-                string swaggerRequeryBehaviorSetting = programState.GetStringPreference(WellKnownPreference.SwaggerRequeryBehavior, "auto");
+                string swaggerRequeryBehaviorSetting = _preferences.GetValue(WellKnownPreference.SwaggerRequeryBehavior, "auto");
 
                 if (swaggerRequeryBehaviorSetting.StartsWith("auto", StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Microsoft.HttpRepl/Commands/OptionsCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/OptionsCommand.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.HttpRepl.FileSystem;
+using Microsoft.HttpRepl.Preferences;
 
 namespace Microsoft.HttpRepl.Commands
 {
     public class OptionsCommand : BaseHttpCommand
     {
-        public OptionsCommand(IFileSystem fileSystem) : base(fileSystem) { }
+        public OptionsCommand(IFileSystem fileSystem, IPreferences preferences) : base(fileSystem, preferences) { }
 
         protected override string Verb => "options";
 

--- a/src/Microsoft.HttpRepl/Commands/PatchCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/PatchCommand.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.HttpRepl.FileSystem;
+using Microsoft.HttpRepl.Preferences;
 
 namespace Microsoft.HttpRepl.Commands
 {
     public class PatchCommand : BaseHttpCommand
     {
-        public PatchCommand(IFileSystem fileSystem) : base(fileSystem) { }
+        public PatchCommand(IFileSystem fileSystem, IPreferences preferences) : base(fileSystem, preferences) { }
 
         protected override string Verb => "patch";
 

--- a/src/Microsoft.HttpRepl/Commands/PostCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/PostCommand.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.HttpRepl.FileSystem;
+using Microsoft.HttpRepl.Preferences;
 
 namespace Microsoft.HttpRepl.Commands
 {
     public class PostCommand : BaseHttpCommand
     {
-        public PostCommand(IFileSystem fileSystem) : base(fileSystem) { }
+        public PostCommand(IFileSystem fileSystem, IPreferences preferences) : base(fileSystem, preferences) { }
 
         protected override string Verb => "post";
 

--- a/src/Microsoft.HttpRepl/Commands/PutCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/PutCommand.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.HttpRepl.FileSystem;
+using Microsoft.HttpRepl.Preferences;
 
 namespace Microsoft.HttpRepl.Commands
 {
     public class PutCommand : BaseHttpCommand
     {
-        public PutCommand(IFileSystem fileSystem) : base(fileSystem) { }
+        public PutCommand(IFileSystem fileSystem, IPreferences preferences) : base(fileSystem, preferences) { }
 
         protected override string Verb => "put";
 

--- a/src/Microsoft.HttpRepl/HttpState.cs
+++ b/src/Microsoft.HttpRepl/HttpState.cs
@@ -19,9 +19,9 @@ namespace Microsoft.HttpRepl
 
         public HttpClient Client { get; }
 
-        public AllowedColors ErrorColor => this.GetColorPreference(WellKnownPreference.ErrorColor, AllowedColors.BoldRed);
+        public AllowedColors ErrorColor => _preferences.GetColorValue(WellKnownPreference.ErrorColor, AllowedColors.BoldRed);
 
-        public AllowedColors WarningColor => this.GetColorPreference(WellKnownPreference.WarningColor, AllowedColors.BoldYellow);
+        public AllowedColors WarningColor => _preferences.GetColorValue(WellKnownPreference.WarningColor, AllowedColors.BoldYellow);
 
         public Stack<string> PathSections { get; }
 
@@ -37,10 +37,6 @@ namespace Microsoft.HttpRepl
 
         public bool EchoRequest { get; set; }
 
-        public Dictionary<string, string> Preferences { get; }
-
-        public IReadOnlyDictionary<string, string> DefaultPreferences { get; }
-
         public Dictionary<string, IEnumerable<string>> Headers { get; }
 
         public DiagnosticsState DiagnosticsState { get; }
@@ -53,39 +49,16 @@ namespace Microsoft.HttpRepl
             _preferences = preferences;
             Client = new HttpClient();
             PathSections = new Stack<string>();
-            DefaultPreferences = CreateDefaultPreferences();
             Headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase)
             {
                 { "User-Agent", new[] { "HTTP-REPL" } }
             };
-            Preferences = _preferences.ReadPreferences(DefaultPreferences);
             DiagnosticsState = new DiagnosticsState();
         }
 
         public string GetPrompt()
         {
             return $"{GetEffectivePath(new string[0], false, out int _)?.ToString() ?? "(Disconnected)"}~ ";
-        }
-
-        internal static IReadOnlyDictionary<string, string> CreateDefaultPreferences()
-        {
-            return new Dictionary<string, string>
-            {
-                { WellKnownPreference.ProtocolColor, "BoldGreen" },
-                { WellKnownPreference.StatusColor, "BoldYellow" },
-
-                { WellKnownPreference.JsonArrayBraceColor, "BoldCyan" },
-                { WellKnownPreference.JsonCommaColor, "BoldYellow" },
-                { WellKnownPreference.JsonNameColor, "BoldMagenta" },
-                { WellKnownPreference.JsonNameSeparatorColor, "BoldWhite" },
-                { WellKnownPreference.JsonObjectBraceColor, "Cyan" },
-                { WellKnownPreference.JsonColor, "Green" }
-            };
-        }
-
-        public bool SavePreferences()
-        {
-            return _preferences.WritePreferences(Preferences, DefaultPreferences);
         }
 
         public string GetExampleBody(string path, ref string contentType, string method)

--- a/src/Microsoft.HttpRepl/Preferences/IPreferences.cs
+++ b/src/Microsoft.HttpRepl/Preferences/IPreferences.cs
@@ -2,12 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Microsoft.Repl.ConsoleHandling;
 
 namespace Microsoft.HttpRepl.Preferences
 {
     public interface IPreferences
     {
-        Dictionary<string, string> ReadPreferences(IReadOnlyDictionary<string, string> defaultPreferences);
-        bool WritePreferences(Dictionary<string, string> preferences, IReadOnlyDictionary<string, string> defaultPreferences);
+        AllowedColors GetColorValue(string preference, AllowedColors defaultValue = AllowedColors.None);
+        int GetIntValue(string preference, int defaultValue = default);
+        string GetValue(string preference, string defaultValue = default);
+        bool TryGetValue(string preference, out string value);
+        bool SetValue(string preference, string value);
+        IReadOnlyDictionary<string, string> DefaultPreferences { get; }
+        IReadOnlyDictionary<string, string> CurrentPreferences { get; }
     }
 }

--- a/src/Microsoft.HttpRepl/Preferences/JsonConfig.cs
+++ b/src/Microsoft.HttpRepl/Preferences/JsonConfig.cs
@@ -7,39 +7,39 @@ namespace Microsoft.HttpRepl.Preferences
 {
     public class JsonConfig : IJsonConfig
     {
-        private readonly HttpState _state;
+        private readonly IPreferences _preferences;
 
-        public int IndentSize => _state.GetIntPreference(WellKnownPreference.JsonIndentSize, 2);
+        public int IndentSize => _preferences.GetIntValue(WellKnownPreference.JsonIndentSize, 2);
 
-        public AllowedColors DefaultColor => _state.GetColorPreference(WellKnownPreference.JsonColor);
+        public AllowedColors DefaultColor => _preferences.GetColorValue(WellKnownPreference.JsonColor);
 
-        private AllowedColors DefaultBraceColor => _state.GetColorPreference(WellKnownPreference.JsonBraceColor, DefaultSyntaxColor);
+        private AllowedColors DefaultBraceColor => _preferences.GetColorValue(WellKnownPreference.JsonBraceColor, DefaultSyntaxColor);
 
-        private AllowedColors DefaultSyntaxColor => _state.GetColorPreference(WellKnownPreference.JsonSyntaxColor, DefaultColor);
+        private AllowedColors DefaultSyntaxColor => _preferences.GetColorValue(WellKnownPreference.JsonSyntaxColor, DefaultColor);
 
-        private AllowedColors DefaultLiteralColor => _state.GetColorPreference(WellKnownPreference.JsonLiteralColor, DefaultColor);
+        private AllowedColors DefaultLiteralColor => _preferences.GetColorValue(WellKnownPreference.JsonLiteralColor, DefaultColor);
 
-        public AllowedColors ArrayBraceColor => _state.GetColorPreference(WellKnownPreference.JsonArrayBraceColor, DefaultBraceColor);
+        public AllowedColors ArrayBraceColor => _preferences.GetColorValue(WellKnownPreference.JsonArrayBraceColor, DefaultBraceColor);
 
-        public AllowedColors ObjectBraceColor => _state.GetColorPreference(WellKnownPreference.JsonObjectBraceColor, DefaultBraceColor);
+        public AllowedColors ObjectBraceColor => _preferences.GetColorValue(WellKnownPreference.JsonObjectBraceColor, DefaultBraceColor);
 
-        public AllowedColors CommaColor => _state.GetColorPreference(WellKnownPreference.JsonCommaColor, DefaultSyntaxColor);
+        public AllowedColors CommaColor => _preferences.GetColorValue(WellKnownPreference.JsonCommaColor, DefaultSyntaxColor);
 
-        public AllowedColors NameColor => _state.GetColorPreference(WellKnownPreference.JsonNameColor, StringColor);
+        public AllowedColors NameColor => _preferences.GetColorValue(WellKnownPreference.JsonNameColor, StringColor);
 
-        public AllowedColors NameSeparatorColor => _state.GetColorPreference(WellKnownPreference.JsonNameSeparatorColor, DefaultSyntaxColor);
+        public AllowedColors NameSeparatorColor => _preferences.GetColorValue(WellKnownPreference.JsonNameSeparatorColor, DefaultSyntaxColor);
 
-        public AllowedColors BoolColor => _state.GetColorPreference(WellKnownPreference.JsonBoolColor, DefaultLiteralColor);
+        public AllowedColors BoolColor => _preferences.GetColorValue(WellKnownPreference.JsonBoolColor, DefaultLiteralColor);
 
-        public AllowedColors NumericColor => _state.GetColorPreference(WellKnownPreference.JsonNumericColor, DefaultLiteralColor);
+        public AllowedColors NumericColor => _preferences.GetColorValue(WellKnownPreference.JsonNumericColor, DefaultLiteralColor);
 
-        public AllowedColors StringColor => _state.GetColorPreference(WellKnownPreference.JsonStringColor, DefaultLiteralColor);
+        public AllowedColors StringColor => _preferences.GetColorValue(WellKnownPreference.JsonStringColor, DefaultLiteralColor);
 
-        public AllowedColors NullColor => _state.GetColorPreference(WellKnownPreference.JsonNullColor, DefaultLiteralColor);
+        public AllowedColors NullColor => _preferences.GetColorValue(WellKnownPreference.JsonNullColor, DefaultLiteralColor);
 
-        public JsonConfig(HttpState state)
+        public JsonConfig(IPreferences preferences)
         {
-            _state = state;
+            _preferences = preferences;
         }
     }
 }

--- a/src/Microsoft.HttpRepl/Preferences/RequestConfig.cs
+++ b/src/Microsoft.HttpRepl/Preferences/RequestConfig.cs
@@ -7,43 +7,43 @@ namespace Microsoft.HttpRepl.Preferences
 {
     public class RequestConfig : RequestOrResponseConfig
     {
-        public RequestConfig(HttpState state)
-            : base(state)
+        public RequestConfig(IPreferences preferences)
+            : base(preferences)
         {
         }
 
-        public override AllowedColors BodyColor => State.GetColorPreference(WellKnownPreference.RequestBodyColor, base.BodyColor);
+        public override AllowedColors BodyColor => Preferences.GetColorValue(WellKnownPreference.RequestBodyColor, base.BodyColor);
 
-        public override AllowedColors SchemeColor => State.GetColorPreference(WellKnownPreference.RequestSchemeColor, base.SchemeColor);
+        public override AllowedColors SchemeColor => Preferences.GetColorValue(WellKnownPreference.RequestSchemeColor, base.SchemeColor);
 
-        public override AllowedColors HeaderKeyColor => State.GetColorPreference(WellKnownPreference.RequestHeaderKeyColor, base.HeaderKeyColor);
+        public override AllowedColors HeaderKeyColor => Preferences.GetColorValue(WellKnownPreference.RequestHeaderKeyColor, base.HeaderKeyColor);
 
-        public override AllowedColors HeaderSeparatorColor => State.GetColorPreference(WellKnownPreference.RequestHeaderSeparatorColor, base.HeaderSeparatorColor);
+        public override AllowedColors HeaderSeparatorColor => Preferences.GetColorValue(WellKnownPreference.RequestHeaderSeparatorColor, base.HeaderSeparatorColor);
 
-        public override AllowedColors HeaderValueSeparatorColor => State.GetColorPreference(WellKnownPreference.RequestHeaderValueSeparatorColor, base.HeaderValueSeparatorColor);
+        public override AllowedColors HeaderValueSeparatorColor => Preferences.GetColorValue(WellKnownPreference.RequestHeaderValueSeparatorColor, base.HeaderValueSeparatorColor);
 
-        public override AllowedColors HeaderValueColor => State.GetColorPreference(WellKnownPreference.RequestHeaderValueColor, base.HeaderValueColor);
+        public override AllowedColors HeaderValueColor => Preferences.GetColorValue(WellKnownPreference.RequestHeaderValueColor, base.HeaderValueColor);
 
-        public override AllowedColors HeaderColor => State.GetColorPreference(WellKnownPreference.RequestHeaderColor, base.HeaderColor);
+        public override AllowedColors HeaderColor => Preferences.GetColorValue(WellKnownPreference.RequestHeaderColor, base.HeaderColor);
 
-        public override AllowedColors GeneralColor => State.GetColorPreference(WellKnownPreference.RequestColor, base.GeneralColor);
+        public override AllowedColors GeneralColor => Preferences.GetColorValue(WellKnownPreference.RequestColor, base.GeneralColor);
 
-        public override AllowedColors ProtocolColor => State.GetColorPreference(WellKnownPreference.RequestProtocolColor, base.ProtocolColor);
+        public override AllowedColors ProtocolColor => Preferences.GetColorValue(WellKnownPreference.RequestProtocolColor, base.ProtocolColor);
 
-        public override AllowedColors ProtocolNameColor => State.GetColorPreference(WellKnownPreference.RequestProtocolNameColor, base.ProtocolNameColor);
+        public override AllowedColors ProtocolNameColor => Preferences.GetColorValue(WellKnownPreference.RequestProtocolNameColor, base.ProtocolNameColor);
 
-        public override AllowedColors ProtocolVersionColor => State.GetColorPreference(WellKnownPreference.RequestProtocolVersionColor, base.ProtocolVersionColor);
+        public override AllowedColors ProtocolVersionColor => Preferences.GetColorValue(WellKnownPreference.RequestProtocolVersionColor, base.ProtocolVersionColor);
 
-        public override AllowedColors ProtocolSeparatorColor => State.GetColorPreference(WellKnownPreference.RequestProtocolSeparatorColor, base.ProtocolSeparatorColor);
+        public override AllowedColors ProtocolSeparatorColor => Preferences.GetColorValue(WellKnownPreference.RequestProtocolSeparatorColor, base.ProtocolSeparatorColor);
 
-        public override AllowedColors StatusColor => State.GetColorPreference(WellKnownPreference.RequestStatusColor, base.StatusColor);
+        public override AllowedColors StatusColor => Preferences.GetColorValue(WellKnownPreference.RequestStatusColor, base.StatusColor);
 
-        public override AllowedColors StatusCodeColor => State.GetColorPreference(WellKnownPreference.RequestStatusCodeColor, base.StatusCodeColor);
+        public override AllowedColors StatusCodeColor => Preferences.GetColorValue(WellKnownPreference.RequestStatusCodeColor, base.StatusCodeColor);
 
-        public override AllowedColors StatusReasonPhraseColor => State.GetColorPreference(WellKnownPreference.RequestStatusReaseonPhraseColor, base.StatusReasonPhraseColor);
+        public override AllowedColors StatusReasonPhraseColor => Preferences.GetColorValue(WellKnownPreference.RequestStatusReaseonPhraseColor, base.StatusReasonPhraseColor);
 
-        public AllowedColors MethodColor => State.GetColorPreference(WellKnownPreference.RequestMethodColor, GeneralColor);
+        public AllowedColors MethodColor => Preferences.GetColorValue(WellKnownPreference.RequestMethodColor, GeneralColor);
 
-        public AllowedColors AddressColor => State.GetColorPreference(WellKnownPreference.RequestAddressColor, GeneralColor);
+        public AllowedColors AddressColor => Preferences.GetColorValue(WellKnownPreference.RequestAddressColor, GeneralColor);
     }
 }

--- a/src/Microsoft.HttpRepl/Preferences/RequestOrResponseConfig.cs
+++ b/src/Microsoft.HttpRepl/Preferences/RequestOrResponseConfig.cs
@@ -7,41 +7,41 @@ namespace Microsoft.HttpRepl.Preferences
 {
     public abstract class RequestOrResponseConfig
     {
-        protected HttpState State { get; }
+        protected IPreferences Preferences { get; }
 
-        protected RequestOrResponseConfig(HttpState state)
+        protected RequestOrResponseConfig(IPreferences preferences)
         {
-            State = state;
+            Preferences = preferences;
         }
 
-        public virtual AllowedColors BodyColor => State.GetColorPreference(WellKnownPreference.BodyColor, GeneralColor);
+        public virtual AllowedColors BodyColor => Preferences.GetColorValue(WellKnownPreference.BodyColor, GeneralColor);
 
-        public virtual AllowedColors SchemeColor => State.GetColorPreference(WellKnownPreference.SchemeColor, GeneralColor);
+        public virtual AllowedColors SchemeColor => Preferences.GetColorValue(WellKnownPreference.SchemeColor, GeneralColor);
 
-        public virtual AllowedColors HeaderKeyColor => State.GetColorPreference(WellKnownPreference.HeaderKeyColor, HeaderColor);
+        public virtual AllowedColors HeaderKeyColor => Preferences.GetColorValue(WellKnownPreference.HeaderKeyColor, HeaderColor);
 
-        public virtual AllowedColors HeaderSeparatorColor => State.GetColorPreference(WellKnownPreference.HeaderSeparatorColor, HeaderColor);
+        public virtual AllowedColors HeaderSeparatorColor => Preferences.GetColorValue(WellKnownPreference.HeaderSeparatorColor, HeaderColor);
 
-        public virtual AllowedColors HeaderValueSeparatorColor => State.GetColorPreference(WellKnownPreference.HeaderValueSeparatorColor, HeaderSeparatorColor);
+        public virtual AllowedColors HeaderValueSeparatorColor => Preferences.GetColorValue(WellKnownPreference.HeaderValueSeparatorColor, HeaderSeparatorColor);
 
-        public virtual AllowedColors HeaderValueColor => State.GetColorPreference(WellKnownPreference.HeaderValueColor, HeaderColor);
+        public virtual AllowedColors HeaderValueColor => Preferences.GetColorValue(WellKnownPreference.HeaderValueColor, HeaderColor);
 
-        public virtual AllowedColors HeaderColor => State.GetColorPreference(WellKnownPreference.HeaderColor, GeneralColor);
+        public virtual AllowedColors HeaderColor => Preferences.GetColorValue(WellKnownPreference.HeaderColor, GeneralColor);
 
-        public virtual AllowedColors GeneralColor => State.GetColorPreference(WellKnownPreference.RequestOrResponseColor);
+        public virtual AllowedColors GeneralColor => Preferences.GetColorValue(WellKnownPreference.RequestOrResponseColor);
 
-        public virtual AllowedColors ProtocolColor => State.GetColorPreference(WellKnownPreference.ProtocolColor, GeneralColor);
+        public virtual AllowedColors ProtocolColor => Preferences.GetColorValue(WellKnownPreference.ProtocolColor, GeneralColor);
 
-        public virtual AllowedColors ProtocolNameColor => State.GetColorPreference(WellKnownPreference.ProtocolNameColor, ProtocolColor);
+        public virtual AllowedColors ProtocolNameColor => Preferences.GetColorValue(WellKnownPreference.ProtocolNameColor, ProtocolColor);
 
-        public virtual AllowedColors ProtocolVersionColor => State.GetColorPreference(WellKnownPreference.ProtocolVersionColor, ProtocolColor);
+        public virtual AllowedColors ProtocolVersionColor => Preferences.GetColorValue(WellKnownPreference.ProtocolVersionColor, ProtocolColor);
 
-        public virtual AllowedColors ProtocolSeparatorColor => State.GetColorPreference(WellKnownPreference.ProtocolSeparatorColor, ProtocolColor);
+        public virtual AllowedColors ProtocolSeparatorColor => Preferences.GetColorValue(WellKnownPreference.ProtocolSeparatorColor, ProtocolColor);
 
-        public virtual AllowedColors StatusColor => State.GetColorPreference(WellKnownPreference.StatusColor, GeneralColor);
+        public virtual AllowedColors StatusColor => Preferences.GetColorValue(WellKnownPreference.StatusColor, GeneralColor);
 
-        public virtual AllowedColors StatusCodeColor => State.GetColorPreference(WellKnownPreference.StatusCodeColor, StatusColor);
+        public virtual AllowedColors StatusCodeColor => Preferences.GetColorValue(WellKnownPreference.StatusCodeColor, StatusColor);
 
-        public virtual AllowedColors StatusReasonPhraseColor => State.GetColorPreference(WellKnownPreference.StatusReaseonPhraseColor, StatusColor);
+        public virtual AllowedColors StatusReasonPhraseColor => Preferences.GetColorValue(WellKnownPreference.StatusReaseonPhraseColor, StatusColor);
     }
 }

--- a/src/Microsoft.HttpRepl/Preferences/ResponseConfig.cs
+++ b/src/Microsoft.HttpRepl/Preferences/ResponseConfig.cs
@@ -7,39 +7,39 @@ namespace Microsoft.HttpRepl.Preferences
 {
     public class ResponseConfig : RequestOrResponseConfig
     {
-        public ResponseConfig(HttpState state)
-            : base(state)
+        public ResponseConfig(IPreferences preferences)
+            : base(preferences)
         {
         }
 
-        public override AllowedColors BodyColor => State.GetColorPreference(WellKnownPreference.ResponseBodyColor, base.BodyColor);
+        public override AllowedColors BodyColor => Preferences.GetColorValue(WellKnownPreference.ResponseBodyColor, base.BodyColor);
 
-        public override AllowedColors SchemeColor => State.GetColorPreference(WellKnownPreference.ResponseSchemeColor, base.SchemeColor);
+        public override AllowedColors SchemeColor => Preferences.GetColorValue(WellKnownPreference.ResponseSchemeColor, base.SchemeColor);
 
-        public override AllowedColors HeaderKeyColor => State.GetColorPreference(WellKnownPreference.ResponseHeaderKeyColor, base.HeaderKeyColor);
+        public override AllowedColors HeaderKeyColor => Preferences.GetColorValue(WellKnownPreference.ResponseHeaderKeyColor, base.HeaderKeyColor);
 
-        public override AllowedColors HeaderSeparatorColor => State.GetColorPreference(WellKnownPreference.ResponseHeaderSeparatorColor, base.HeaderSeparatorColor);
+        public override AllowedColors HeaderSeparatorColor => Preferences.GetColorValue(WellKnownPreference.ResponseHeaderSeparatorColor, base.HeaderSeparatorColor);
 
-        public override AllowedColors HeaderValueSeparatorColor => State.GetColorPreference(WellKnownPreference.ResponseHeaderValueSeparatorColor, base.HeaderValueSeparatorColor);
+        public override AllowedColors HeaderValueSeparatorColor => Preferences.GetColorValue(WellKnownPreference.ResponseHeaderValueSeparatorColor, base.HeaderValueSeparatorColor);
 
-        public override AllowedColors HeaderValueColor => State.GetColorPreference(WellKnownPreference.ResponseHeaderValueColor, base.HeaderValueColor);
+        public override AllowedColors HeaderValueColor => Preferences.GetColorValue(WellKnownPreference.ResponseHeaderValueColor, base.HeaderValueColor);
 
-        public override AllowedColors HeaderColor => State.GetColorPreference(WellKnownPreference.ResponseHeaderColor, base.HeaderColor);
+        public override AllowedColors HeaderColor => Preferences.GetColorValue(WellKnownPreference.ResponseHeaderColor, base.HeaderColor);
 
-        public override AllowedColors GeneralColor => State.GetColorPreference(WellKnownPreference.ResponseColor, base.GeneralColor);
+        public override AllowedColors GeneralColor => Preferences.GetColorValue(WellKnownPreference.ResponseColor, base.GeneralColor);
 
-        public override AllowedColors ProtocolColor => State.GetColorPreference(WellKnownPreference.ResponseProtocolColor, base.ProtocolColor);
+        public override AllowedColors ProtocolColor => Preferences.GetColorValue(WellKnownPreference.ResponseProtocolColor, base.ProtocolColor);
 
-        public override AllowedColors ProtocolNameColor => State.GetColorPreference(WellKnownPreference.ResponseProtocolNameColor, base.ProtocolNameColor);
+        public override AllowedColors ProtocolNameColor => Preferences.GetColorValue(WellKnownPreference.ResponseProtocolNameColor, base.ProtocolNameColor);
 
-        public override AllowedColors ProtocolVersionColor => State.GetColorPreference(WellKnownPreference.ResponseProtocolVersionColor, base.ProtocolVersionColor);
+        public override AllowedColors ProtocolVersionColor => Preferences.GetColorValue(WellKnownPreference.ResponseProtocolVersionColor, base.ProtocolVersionColor);
 
-        public override AllowedColors ProtocolSeparatorColor => State.GetColorPreference(WellKnownPreference.ResponseProtocolSeparatorColor, base.ProtocolSeparatorColor);
+        public override AllowedColors ProtocolSeparatorColor => Preferences.GetColorValue(WellKnownPreference.ResponseProtocolSeparatorColor, base.ProtocolSeparatorColor);
 
-        public override AllowedColors StatusColor => State.GetColorPreference(WellKnownPreference.ResponseStatusColor, base.StatusColor);
+        public override AllowedColors StatusColor => Preferences.GetColorValue(WellKnownPreference.ResponseStatusColor, base.StatusColor);
 
-        public override AllowedColors StatusCodeColor => State.GetColorPreference(WellKnownPreference.ResponseStatusCodeColor, base.StatusCodeColor);
+        public override AllowedColors StatusCodeColor => Preferences.GetColorValue(WellKnownPreference.ResponseStatusCodeColor, base.StatusCodeColor);
 
-        public override AllowedColors StatusReasonPhraseColor => State.GetColorPreference(WellKnownPreference.ResponseStatusReaseonPhraseColor, base.StatusReasonPhraseColor);
+        public override AllowedColors StatusReasonPhraseColor => Preferences.GetColorValue(WellKnownPreference.ResponseStatusReaseonPhraseColor, base.StatusReasonPhraseColor);
     }
 }

--- a/src/Microsoft.HttpRepl/Preferences/UserFolderPreferences.cs
+++ b/src/Microsoft.HttpRepl/Preferences/UserFolderPreferences.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using Microsoft.HttpRepl.FileSystem;
 using Microsoft.HttpRepl.UserProfile;
+using Microsoft.Repl.ConsoleHandling;
 
 namespace Microsoft.HttpRepl.Preferences
 {
@@ -15,6 +17,23 @@ namespace Microsoft.HttpRepl.Preferences
         private string _prefsFilePath;
         private readonly IFileSystem _fileSystem;
         private readonly IUserProfileDirectoryProvider _userProfileDirectoryProvider;
+
+        private Dictionary<string, string> _preferences;
+
+        private Dictionary<string, string> Preferences
+        {
+            get
+            {
+                if (_preferences == null)
+                {
+                    _preferences = ReadPreferences(DefaultPreferences);
+                }
+
+                return _preferences;
+            }
+        }
+
+        public IReadOnlyDictionary<string, string> DefaultPreferences { get; }
 
         public string PreferencesFilePath
         {
@@ -27,15 +46,80 @@ namespace Microsoft.HttpRepl.Preferences
                 }
                 return _prefsFilePath;
             }
-        }         
+        }
 
-        public UserFolderPreferences(IFileSystem fileSystem, IUserProfileDirectoryProvider userProfileDirectoryProvider)
+        public UserFolderPreferences(IFileSystem fileSystem, IUserProfileDirectoryProvider userProfileDirectoryProvider, IDictionary<string, string> defaultPreferences)
         {
             _fileSystem = fileSystem;
             _userProfileDirectoryProvider = userProfileDirectoryProvider;
+            DefaultPreferences = SetupDefaults(defaultPreferences);
         }
 
-        public Dictionary<string, string> ReadPreferences(IReadOnlyDictionary<string, string> defaultPreferences)
+        public AllowedColors GetColorValue(string preference, AllowedColors defaultValue = AllowedColors.None)
+        {
+            if (!Preferences.TryGetValue(preference, out string preferenceValueString) || !Enum.TryParse(preferenceValueString, true, out AllowedColors result))
+            {
+                result = defaultValue;
+            }
+
+            return result;
+        }
+
+        public int GetIntValue(string preference, int defaultValue)
+        {
+            if (!Preferences.TryGetValue(preference, out string preferenceValueString) || !int.TryParse(preferenceValueString, out int result))
+            {
+                result = defaultValue;
+            }
+
+            return result;
+        }
+
+        public string GetValue(string preference, string defaultValue = default)
+        {
+            if (!Preferences.TryGetValue(preference, out string result))
+            {
+                result = defaultValue;
+            }
+
+            return result;
+        }
+
+        public bool TryGetValue(string preference, out string value)
+        {
+            return Preferences.TryGetValue(preference, out value);
+        }
+
+        public bool SetValue(string preference, string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                if (!DefaultPreferences.TryGetValue(preference, out string defaultValue))
+                {
+                    Preferences.Remove(preference);
+                }
+                else
+                {
+                    Preferences[preference] = defaultValue;
+                }
+            }
+            else
+            {
+                Preferences[preference] = value;
+            }
+
+            return WritePreferences(Preferences, DefaultPreferences);
+        }
+
+        public IReadOnlyDictionary<string, string> CurrentPreferences
+        {
+            get
+            {
+                return new ReadOnlyDictionary<string, string>(Preferences);
+            }
+        }
+
+        private Dictionary<string, string> ReadPreferences(IReadOnlyDictionary<string, string> defaultPreferences)
         {
             var preferences = new Dictionary<string, string>(defaultPreferences);
 
@@ -49,7 +133,7 @@ namespace Microsoft.HttpRepl.Preferences
 
                     // If there's no = or = is the first character on the line
                     // (meaning no preference name), move to the next line
-                    if (equalsIndex <= 0) 
+                    if (equalsIndex <= 0)
                     {
                         continue;
                     }
@@ -61,7 +145,7 @@ namespace Microsoft.HttpRepl.Preferences
             return preferences;
         }
 
-        public bool WritePreferences(Dictionary<string, string> preferences, IReadOnlyDictionary<string, string> defaultPreferences)
+        private bool WritePreferences(Dictionary<string, string> preferences, IReadOnlyDictionary<string, string> defaultPreferences)
         {
             List<string> lines = new List<string>();
             foreach (KeyValuePair<string, string> entry in preferences.OrderBy(x => x.Key))
@@ -82,6 +166,21 @@ namespace Microsoft.HttpRepl.Preferences
             {
                 return false;
             }
+        }
+
+        private IReadOnlyDictionary<string, string> SetupDefaults(IDictionary<string, string> defaults)
+        {
+            Dictionary<string, string> tempDictionary = new Dictionary<string, string>();
+
+            if (defaults != null)
+            {
+                foreach (var kvp in defaults)
+                {
+                    tempDictionary.Add(kvp.Key, kvp.Value);
+                }
+            }
+
+            return new ReadOnlyDictionary<string, string>(tempDictionary);
         }
     }
 }

--- a/src/Microsoft.HttpRepl/Preferences/WellKnownPreference.cs
+++ b/src/Microsoft.HttpRepl/Preferences/WellKnownPreference.cs
@@ -1,10 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Microsoft.Repl.ConsoleHandling;
 
 namespace Microsoft.HttpRepl.Preferences
 {
@@ -173,34 +171,34 @@ namespace Microsoft.HttpRepl.Preferences
         public static string SwaggerRequeryBehavior { get; } = "swagger.requery";
 
 
-        public static AllowedColors GetColorPreference(this HttpState programState, string preference, AllowedColors defaultvalue = AllowedColors.None)
-        {
-            if (!programState.Preferences.TryGetValue(preference, out string preferenceValueString) || !Enum.TryParse(preferenceValueString, true, out AllowedColors result))
-            {
-                result = defaultvalue;
-            }
+        //public static AllowedColors GetColorPreference(this HttpState programState, string preference, AllowedColors defaultvalue = AllowedColors.None)
+        //{
+        //    if (!programState.Preferences.TryGetValue(preference, out string preferenceValueString) || !Enum.TryParse(preferenceValueString, true, out AllowedColors result))
+        //    {
+        //        result = defaultvalue;
+        //    }
 
-            return result;
-        }
+        //    return result;
+        //}
 
-        public static int GetIntPreference(this HttpState programState, string preference, int defaultValue = 0)
-        {
-            if (!programState.Preferences.TryGetValue(preference, out string preferenceValueString) || !int.TryParse(preferenceValueString, out int result))
-            {
-                result = defaultValue;
-            }
+        //public static int GetIntPreference(this HttpState programState, string preference, int defaultValue = 0)
+        //{
+        //    if (!programState.Preferences.TryGetValue(preference, out string preferenceValueString) || !int.TryParse(preferenceValueString, out int result))
+        //    {
+        //        result = defaultValue;
+        //    }
 
-            return result;
-        }
+        //    return result;
+        //}
 
-        public static string GetStringPreference(this HttpState programState, string preference, string defaultValue = null)
-        {
-            if (!programState.Preferences.TryGetValue(preference, out string result))
-            {
-                result = defaultValue;
-            }
+        //public static string GetStringPreference(this HttpState programState, string preference, string defaultValue = null)
+        //{
+        //    if (!programState.Preferences.TryGetValue(preference, out string result))
+        //    {
+        //        result = defaultValue;
+        //    }
 
-            return result;
-        }
+        //    return result;
+        //}
     }
 }

--- a/src/Microsoft.HttpRepl/Preferences/WellKnownPreference.cs
+++ b/src/Microsoft.HttpRepl/Preferences/WellKnownPreference.cs
@@ -169,36 +169,5 @@ namespace Microsoft.HttpRepl.Preferences
         public static string DefaultEditorArguments { get; } = "editor.command.default.arguments";
 
         public static string SwaggerRequeryBehavior { get; } = "swagger.requery";
-
-
-        //public static AllowedColors GetColorPreference(this HttpState programState, string preference, AllowedColors defaultvalue = AllowedColors.None)
-        //{
-        //    if (!programState.Preferences.TryGetValue(preference, out string preferenceValueString) || !Enum.TryParse(preferenceValueString, true, out AllowedColors result))
-        //    {
-        //        result = defaultvalue;
-        //    }
-
-        //    return result;
-        //}
-
-        //public static int GetIntPreference(this HttpState programState, string preference, int defaultValue = 0)
-        //{
-        //    if (!programState.Preferences.TryGetValue(preference, out string preferenceValueString) || !int.TryParse(preferenceValueString, out int result))
-        //    {
-        //        result = defaultValue;
-        //    }
-
-        //    return result;
-        //}
-
-        //public static string GetStringPreference(this HttpState programState, string preference, string defaultValue = null)
-        //{
-        //    if (!programState.Preferences.TryGetValue(preference, out string result))
-        //    {
-        //        result = defaultValue;
-        //    }
-
-        //    return result;
-        //}
     }
 }


### PR DESCRIPTION
This PR is a response to conversations I had with @jimmylewis while working on #41 (the tests for `PrefCommand` and related classes). The preferences system was spread out across multiple classes in a way that made it hard to follow and test.

This PR attempts to correct that by moving most of the logic into the `IPreferences` implementation `UserFolderPreferences`.

In particular:

1. Preferences are no longer held in memory in the `HttpState` object and accessed directly off that in an almost-global manner. 
2. There's no longer a requirement to explicitly read the settings at startup and write them after every setting change. That is handled by the `UserFolderPreferences` under the hood, allowing the settings to be lazy loaded and, if we chose, delay-written. That latter part is not implemented as part of this PR right now.
3. The logic of handling the defaults values versus the current values is no longer handled in the `PrefCommand`, and is instead part of `UserFolderPreferences`. `PrefCommand` can thus focus on what it really needs to do, which is handle the user command and route it appropriately to the preferences system.
4. The default preferences were moved out of `HttpState` and into `Program`, since they're not really tied to `HttpState`. They are currently still used by the test cases, but that is now encapsulated a little better to allow separation if we chose.