### PR TITLE
List -h as an alias to the --help option

### DIFF
--- a/src/Microsoft.HttpRepl/Program.cs
+++ b/src/Microsoft.HttpRepl/Program.cs
@@ -70,7 +70,7 @@ namespace Microsoft.HttpRepl
                     shell.ShellState.ConsoleManager.WriteLine(string.Format(Resources.Strings.Help_BaseAddress, "<BASE_ADDRESS>"));
                     shell.ShellState.ConsoleManager.WriteLine();
                     shell.ShellState.ConsoleManager.WriteLine(Resources.Strings.Help_Options);
-                    shell.ShellState.ConsoleManager.WriteLine(string.Format(Resources.Strings.Help_Help, "--help"));
+                    shell.ShellState.ConsoleManager.WriteLine(string.Format(Resources.Strings.Help_Help, "-h|--help"));
 
                     shell.ShellState.ConsoleManager.WriteLine();
                     shell.ShellState.ConsoleManager.WriteLine(Resources.Strings.Help_REPLCommands);


### PR DESCRIPTION
The `Program` class' `Start` method includes code that checks for `-h`. This PR lists `-h` as a shorthand option alternative to `--help`.