### PR TITLE
Initialize HTTP request headers Dictionary as case-insensitive

### DIFF
--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -99,7 +99,7 @@ namespace Microsoft.HttpRepl.Commands
                 }
             }
 
-            Dictionary<string, string> thisRequestHeaders = new Dictionary<string, string>();
+            Dictionary<string, string> thisRequestHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (InputElement header in commandInput.Options[HeaderOption])
             {


### PR DESCRIPTION
This is a small fix for something I noticed while writing the doc. The generic dictionary used for storing HTTP request headers should be created as case-insensitive (as most others in the code base are). Without that change, the first condition in the following if statement is problematic:

https://github.com/aspnet/HttpRepl/blob/e261002df7f7d96f26337b2057b6e3f31dfe88da/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs#L128

Imagine a situation in which I execute the following command:

```console
https://localhost:5001/People~ post -h Content-Type=application/json
```

The HTTP request header uses a different casing than what the if statement is expecting. With a case-insensitive dictionary, the casing in this situation no longer matters.


