### PR TITLE
Using ICommand.GetHelpSummary from the HelpCommand

### DIFF
--- a/src/Microsoft.HttpRepl/Commands/ChangeDirectoryCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ChangeDirectoryCommand.cs
@@ -86,7 +86,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public override string GetHelpSummary(IShellState shellState, HttpState programState)
         {
-            return "cd [directory name] - Prints the current directory if no argument is specified, otherwise changes to the specified directory";
+            return Resources.Strings.ChangeDirectoryCommand_HelpSummary;
         }
 
         protected override IEnumerable<string> GetArgumentSuggestionsForText(IShellState shellState, HttpState programState, ICoreParseResult parseResult, DefaultCommandInput<ICoreParseResult> commandInput, string normalCompletionString)

--- a/src/Microsoft.HttpRepl/Commands/ClearCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ClearCommand.cs
@@ -42,7 +42,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public string GetHelpSummary(IShellState shellState, object programState)
         {
-            return "clear - Clears the shell";
+            return Resources.Strings.ClearCommand_HelpSummary;
         }
 
         public IEnumerable<string> Suggest(IShellState shellState, object programState, ICoreParseResult parseResult)

--- a/src/Microsoft.HttpRepl/Commands/CommandDispatcherExtensions.cs
+++ b/src/Microsoft.HttpRepl/Commands/CommandDispatcherExtensions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.Repl.Commanding;
+using Microsoft.Repl.Parsing;
+
+namespace Microsoft.HttpRepl.Commands
+{
+    internal static class CommandDispatcherExtensions
+    {
+        public static T GetCommand<T>(this ICommandDispatcher<HttpState, ICoreParseResult> dispatcher) where T : ICommand<HttpState, ICoreParseResult>
+        {
+            return dispatcher.Commands.OfType<T>().FirstOrDefault();
+        }
+    }
+}

--- a/src/Microsoft.HttpRepl/Commands/EchoCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/EchoCommand.cs
@@ -52,7 +52,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public override string GetHelpSummary(IShellState shellState, HttpState programState)
         {
-            return "echo [on/off] - Turns request echoing on or off";
+            return Resources.Strings.EchoCommand_HelpSummary;
         }
 
         protected override IEnumerable<string> GetArgumentSuggestionsForText(IShellState shellState, HttpState programState, ICoreParseResult parseResult, DefaultCommandInput<ICoreParseResult> commandInput, string normalCompletionString)

--- a/src/Microsoft.HttpRepl/Commands/ExitCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ExitCommand.cs
@@ -33,7 +33,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public override string GetHelpSummary(IShellState shellState, object programState)
         {
-            return "exit - Exits the shell";
+            return Resources.Strings.ExitCommand_HelpSummary;
         }
     }
 }

--- a/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using Microsoft.HttpRepl.Preferences;
 using Microsoft.HttpRepl.Suggestions;
 using Microsoft.Repl;
@@ -221,49 +222,56 @@ namespace Microsoft.HttpRepl.Commands
 
             const int navCommandColumn = -15;
 
-            output.AppendLine($"{"GET",navCommandColumn}{"Issues a GET request."}");
-            output.AppendLine($"{"POST",navCommandColumn}{"Issues a POST request."}");
-            output.AppendLine($"{"PUT",navCommandColumn}{"Issues a PUT request."}");
-            output.AppendLine($"{"DELETE",navCommandColumn}{"Issues a DELETE request."}");
-            output.AppendLine($"{"PATCH",navCommandColumn}{"Issues a PATCH request."}");
-            output.AppendLine($"{"HEAD",navCommandColumn}{"Issues a HEAD request."}");
-            output.AppendLine($"{"OPTIONS",navCommandColumn}{"Issues an OPTIONS request."}");
+
+            output.AppendLine($"{"GET",navCommandColumn}{dispatcher.GetCommand<GetCommand>().GetHelpSummary(shellState, programState)}");
+            output.AppendLine($"{"POST",navCommandColumn}{dispatcher.GetCommand<PostCommand>().GetHelpSummary(shellState, programState)}");
+            output.AppendLine($"{"PUT",navCommandColumn}{dispatcher.GetCommand<PutCommand>().GetHelpSummary(shellState, programState)}");
+            output.AppendLine($"{"DELETE",navCommandColumn}{dispatcher.GetCommand<DeleteCommand>().GetHelpSummary(shellState, programState)}");
+            output.AppendLine($"{"PATCH",navCommandColumn}{dispatcher.GetCommand<PatchCommand>().GetHelpSummary(shellState, programState)}");
+            output.AppendLine($"{"HEAD",navCommandColumn}{dispatcher.GetCommand<HeadCommand>().GetHelpSummary(shellState, programState)}");
+            output.AppendLine($"{"OPTIONS",navCommandColumn}{dispatcher.GetCommand<OptionsCommand>().GetHelpSummary(shellState, programState)}");
             output.AppendLine();
-            output.AppendLine($"{"set header",navCommandColumn}{"Sets or clears a header for all requests. e.g. `set header content-type application/json`"}");
-            output.AppendLine();
+            output.AppendLine($"{"set header",navCommandColumn}{dispatcher.GetCommand<SetHeaderCommand>().GetHelpSummary(shellState, programState)}");
 
             output.AppendLine();
             output.AppendLine("Navigation Commands:".Bold().Cyan());
             output.AppendLine("The REPL allows you to navigate your URL space and focus on specific APIs that you are working on.");
             output.AppendLine();
 
-            output.AppendLine($"{"set base",navCommandColumn}{"Set the base URI. e.g. `set base http://locahost:5000`"}");
-            output.AppendLine($"{"set swagger",navCommandColumn}{"Set the URI, relative to your base if set, of the Swagger document for this API. e.g. `set swagger /swagger/v1/swagger.json`"}");
-            output.AppendLine($"{"ls",navCommandColumn}{"Show all endpoints for the current path."}");
-            output.AppendLine($"{"cd",navCommandColumn}{"Append the given directory to the currently selected path, or move up a path when using `cd ..`."}");
+            output.AppendLine($"{"set base",navCommandColumn}{dispatcher.GetCommand<SetBaseCommand>().GetHelpSummary(shellState, programState)}");
+            output.AppendLine($"{"set swagger",navCommandColumn}{dispatcher.GetCommand<SetSwaggerCommand>().GetHelpSummary(shellState, programState)}");
+            output.AppendLine($"{"ls",navCommandColumn}{dispatcher.GetCommand<ListCommand>().GetHelpSummary(shellState, programState)}");
+            output.AppendLine($"{"cd",navCommandColumn}{dispatcher.GetCommand<ChangeDirectoryCommand>().GetHelpSummary(shellState, programState)}");
 
             output.AppendLine();
             output.AppendLine("Shell Commands:".Bold().Cyan());
             output.AppendLine("Use these commands to interact with the REPL shell.");
             output.AppendLine();
 
-            output.AppendLine($"{"clear",navCommandColumn}{"Removes all text from the shell."}");
-            output.AppendLine($"{"echo [on/off]",navCommandColumn}{"Turns request echoing on or off, show the request that was made when using request commands."}");
-            output.AppendLine($"{"exit",navCommandColumn}{"Exit the shell."}");
+            output.AppendLine($"{"clear",navCommandColumn}{dispatcher.GetCommand<ClearCommand>().GetHelpSummary(shellState, programState)}");
+            output.AppendLine($"{"echo [on/off]",navCommandColumn}{dispatcher.GetCommand<EchoCommand>().GetHelpSummary(shellState, programState)}");
+            output.AppendLine($"{"exit",navCommandColumn}{dispatcher.GetCommand<ExitCommand>().GetHelpSummary(shellState, programState)}");
 
             output.AppendLine();
             output.AppendLine("REPL Customization Commands:".Bold().Cyan());
             output.AppendLine("Use these commands to customize the REPL behavior.");
             output.AppendLine();
 
-            output.AppendLine($"{"pref [get/set]",navCommandColumn}{"Allows viewing or changing preferences, e.g. 'pref set editor.command.default 'C:\\Program Files\\Microsoft VS Code\\Code.exe'`"}");
-            output.AppendLine($"{"run",navCommandColumn}{"Runs the script at the given path. A script is a set of commands that can be typed with one command per line."}");
-            output.AppendLine($"{"ui",navCommandColumn}{"Displays the Swagger UI page, if available, in the default browser."}");
+            output.AppendLine($"{"pref [get/set]",navCommandColumn}{dispatcher.GetCommand<PrefCommand>().GetHelpSummary(shellState, programState)}");
+            output.AppendLine($"{"run",navCommandColumn}{dispatcher.GetCommand<RunCommand>().GetHelpSummary(shellState, programState)}");
+            output.AppendLine($"{"ui",navCommandColumn}{dispatcher.GetCommand<UICommand>().GetHelpSummary(shellState, programState)}");
             output.AppendLine();
             output.AppendLine("Use help <COMMAND> to learn more details about individual commands. e.g. `help get`".Bold().Cyan());
             output.AppendLine();
 
             shellState.ConsoleManager.Write(output.ToString());
+        }
+
+        private static T GetCommand<T, TState, TParseResult>(ICommandDispatcher<TState, TParseResult> dispatcher) where T: class, ICommand where TParseResult: ICoreParseResult
+        {
+            var command = dispatcher.Commands?.SingleOrDefault(c => c.GetType() == typeof(T));
+
+            return command as T;
         }
     }
 }

--- a/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
@@ -266,12 +266,5 @@ namespace Microsoft.HttpRepl.Commands
 
             shellState.ConsoleManager.Write(output.ToString());
         }
-
-        private static T GetCommand<T, TState, TParseResult>(ICommandDispatcher<TState, TParseResult> dispatcher) where T: class, ICommand where TParseResult: ICoreParseResult
-        {
-            var command = dispatcher.Commands?.SingleOrDefault(c => c.GetType() == typeof(T));
-
-            return command as T;
-        }
     }
 }

--- a/src/Microsoft.HttpRepl/Commands/ListCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ListCommand.cs
@@ -137,7 +137,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public override string GetHelpSummary(IShellState shellState, HttpState programState)
         {
-            return "ls - List known routes for the current location";
+            return Resources.Strings.ListCommand_HelpSummary;
         }
 
         protected override IEnumerable<string> GetArgumentSuggestionsForText(IShellState shellState, HttpState programState, ICoreParseResult parseResult, DefaultCommandInput<ICoreParseResult> commandInput, string normalCompletionString)

--- a/src/Microsoft.HttpRepl/Commands/RunCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/RunCommand.cs
@@ -70,7 +70,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public string GetHelpSummary(IShellState shellState, HttpState programState)
         {
-            return "run {path to script} - Runs a script";
+            return Resources.Strings.RunCommand_HelpSummary;
         }
 
         public IEnumerable<string> Suggest(IShellState shellState, HttpState programState, ICoreParseResult parseResult)

--- a/src/Microsoft.HttpRepl/Commands/SetBaseCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/SetBaseCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.HttpRepl.Commands
         private const string Name = "set";
         private const string SubCommand = "base";
 
-        public string Description => "Sets the base address to direct requests to.";
+        public string Description => Resources.Strings.SetBaseCommand_HelpSummary;
 
         public bool? CanHandle(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {

--- a/src/Microsoft.HttpRepl/Commands/SetHeaderCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/SetHeaderCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.HttpRepl.Commands
         private static readonly string Name = "set";
         private static readonly string SubCommand = "header";
 
-        public string Description => "set header {name} [value] - Sets or clears a header";
+        public string Description => Resources.Strings.SetHeaderCommand_HelpSummary;
 
         public bool? CanHandle(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
@@ -52,7 +52,7 @@ namespace Microsoft.HttpRepl.Commands
                 helpText.AppendLine("set header {name} [value]");
                 helpText.AppendLine();
                 helpText.AppendLine("Sets or clears a header. When [value] is empty the header is cleared.");
-                return Description;
+                return helpText.ToString();
             }
 
             return null;

--- a/src/Microsoft.HttpRepl/Commands/SetSwaggerCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/SetSwaggerCommand.cs
@@ -23,7 +23,7 @@ namespace Microsoft.HttpRepl.Commands
         private static readonly string Name = "set";
         private static readonly string SubCommand = "swagger";
 
-        public string Description => "Sets the swagger document to use for information about the current server";
+        public string Description => Resources.Strings.SetSwaggerCommand_HelpSummary;
 
         private static void FillDirectoryInfo(DirectoryStructure parent, EndpointMetadata entry)
         {

--- a/src/Microsoft.HttpRepl/Commands/UICommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/UICommand.cs
@@ -64,7 +64,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public string GetHelpSummary(IShellState shellState, HttpState programState)
         {
-            return "ui - Launches the Swagger UI page (if available) in the default browser";
+            return Resources.Strings.UICommand_HelpSummary;
         }
 
         public IEnumerable<string> Suggest(IShellState shellState, HttpState programState, ICoreParseResult parseResult)

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -61,6 +61,33 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Append the given directory to the currently selected path, or move up a path when using `cd ..`.
+        /// </summary>
+        internal static string ChangeDirectoryCommand_HelpSummary {
+            get {
+                return ResourceManager.GetString("ChangeDirectoryCommand_HelpSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removes all text from the shell.
+        /// </summary>
+        internal static string ClearCommand_HelpSummary {
+            get {
+                return ResourceManager.GetString("ClearCommand_HelpSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Turns request echoing on or off, show the request that was made when using request commands.
+        /// </summary>
+        internal static string EchoCommand_HelpSummary {
+            get {
+                return ResourceManager.GetString("EchoCommand_HelpSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;set base {url}&apos; must be called before issuing requests to a relative path.
         /// </summary>
         internal static string Error_NoBasePath {
@@ -75,6 +102,15 @@ namespace Microsoft.HttpRepl.Resources {
         internal static string Error_OutputRedirected {
             get {
                 return ResourceManager.GetString("Error_OutputRedirected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exit the shell.
+        /// </summary>
+        internal static string ExitCommand_HelpSummary {
+            get {
+                return ResourceManager.GetString("ExitCommand_HelpSummary", resourceCulture);
             }
         }
         
@@ -129,6 +165,15 @@ namespace Microsoft.HttpRepl.Resources {
         internal static string Help_Usage {
             get {
                 return ResourceManager.GetString("Help_Usage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show all endpoints for the current path.
+        /// </summary>
+        internal static string ListCommand_HelpSummary {
+            get {
+                return ResourceManager.GetString("ListCommand_HelpSummary", resourceCulture);
             }
         }
         
@@ -223,11 +268,56 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} - Allows viewing or changing preferences.
+        ///   Looks up a localized string similar to Allows viewing or changing preferences, e.g. &apos;pref set editor.command.default &apos;C:\\Program Files\\Microsoft VS Code\\Code.exe&apos;`.
         /// </summary>
         internal static string PrefCommand_HelpSummary {
             get {
                 return ResourceManager.GetString("PrefCommand_HelpSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Runs the script at the given path. A script is a set of commands that can be typed with one command per line.
+        /// </summary>
+        internal static string RunCommand_HelpSummary {
+            get {
+                return ResourceManager.GetString("RunCommand_HelpSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set the base URI. e.g. `set base http://locahost:5000`.
+        /// </summary>
+        internal static string SetBaseCommand_HelpSummary {
+            get {
+                return ResourceManager.GetString("SetBaseCommand_HelpSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sets or clears a header for all requests. e.g. `set header content-type application/json`.
+        /// </summary>
+        internal static string SetHeaderCommand_HelpSummary {
+            get {
+                return ResourceManager.GetString("SetHeaderCommand_HelpSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set the URI, relative to your base if set, of the Swagger document for this API. e.g. `set swagger /swagger/v1/swagger.json`.
+        /// </summary>
+        internal static string SetSwaggerCommand_HelpSummary {
+            get {
+                return ResourceManager.GetString("SetSwaggerCommand_HelpSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Displays the Swagger UI page, if available, in the default browser.
+        /// </summary>
+        internal static string UICommand_HelpSummary {
+            get {
+                return ResourceManager.GetString("UICommand_HelpSummary", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -117,12 +117,24 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ChangeDirectoryCommand_HelpSummary" xml:space="preserve">
+    <value>Append the given directory to the currently selected path, or move up a path when using `cd ..`</value>
+  </data>
+  <data name="ClearCommand_HelpSummary" xml:space="preserve">
+    <value>Removes all text from the shell</value>
+  </data>
+  <data name="EchoCommand_HelpSummary" xml:space="preserve">
+    <value>Turns request echoing on or off, show the request that was made when using request commands</value>
+  </data>
   <data name="Error_NoBasePath" xml:space="preserve">
     <value>'set base {url}' must be called before issuing requests to a relative path</value>
     <comment>Error shown in console when issuing an HTTP command without first setting the base url</comment>
   </data>
   <data name="Error_OutputRedirected" xml:space="preserve">
     <value>Cannot start the REPL when output is being redirected</value>
+  </data>
+  <data name="ExitCommand_HelpSummary" xml:space="preserve">
+    <value>Exit the shell</value>
   </data>
   <data name="Help_Arguments" xml:space="preserve">
     <value>Arguments:</value>
@@ -143,6 +155,9 @@
   </data>
   <data name="Help_Usage" xml:space="preserve">
     <value>Usage: </value>
+  </data>
+  <data name="ListCommand_HelpSummary" xml:space="preserve">
+    <value>Show all endpoints for the current path</value>
   </data>
   <data name="PrefCommand_Error_NoConfiguredValue" xml:space="preserve">
     <value>{0} does not have a configured value</value>
@@ -180,7 +195,21 @@
     <comment>{0} is the overall command syntax</comment>
   </data>
   <data name="PrefCommand_HelpSummary" xml:space="preserve">
-    <value>{0} - Allows viewing or changing preferences</value>
-    <comment>{0} is the command text</comment>
+    <value>Allows viewing or changing preferences, e.g. 'pref set editor.command.default 'C:\\Program Files\\Microsoft VS Code\\Code.exe'`</value>
+  </data>
+  <data name="RunCommand_HelpSummary" xml:space="preserve">
+    <value>Runs the script at the given path. A script is a set of commands that can be typed with one command per line</value>
+  </data>
+  <data name="SetBaseCommand_HelpSummary" xml:space="preserve">
+    <value>Set the base URI. e.g. `set base http://locahost:5000`</value>
+  </data>
+  <data name="SetHeaderCommand_HelpSummary" xml:space="preserve">
+    <value>Sets or clears a header for all requests. e.g. `set header content-type application/json`</value>
+  </data>
+  <data name="SetSwaggerCommand_HelpSummary" xml:space="preserve">
+    <value>Set the URI, relative to your base if set, of the Swagger document for this API. e.g. `set swagger /swagger/v1/swagger.json`</value>
+  </data>
+  <data name="UICommand_HelpSummary" xml:space="preserve">
+    <value>Displays the Swagger UI page, if available, in the default browser</value>
   </data>
 </root>


### PR DESCRIPTION
This is a replacement PR for #48 to fix #43. 

`HelpCommand.GetCoreHelp(...)` had all of the help summaries hard-coded. This PR changes it to use the ICommand.GetHelpSummary(...) for each command. It also moves the strings used for GetHelpSummary into Resources.