### PR TITLE
Add an integration test with the Swagger endpoint disabled

### DIFF
--- a/src/Microsoft.HttpRepl.IntegrationTests/BaseIntegrationTest.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/BaseIntegrationTest.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.HttpRepl.IntegrationTests
+{
+    public class BaseIntegrationTest
+    {
+
+        protected static string NormalizeOutput(string output, string baseUrl)
+        {
+            // The console implementation uses trailing whitespace when a new line's text is shorter than the previous
+            // line.  For example (the trailing * represent spaces):
+            // Line 1: (Disconnected)~ run C:\path\to\a\test\script\file.txt
+            // Line 2: (Disconnected)~ set base http://localhost:12345******
+            // This having this whitespace makes it harder to read/write test baselines, so here we'll trim each line
+            string result = string.Join(Environment.NewLine, output.Split(Environment.NewLine).Select(l => l.TrimEnd()));
+
+            // next, normalize the base URL from the test fixture
+            if (!string.IsNullOrEmpty(baseUrl))
+            {
+                result = result.Replace(baseUrl, "[BaseUrl]");
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.HttpRepl.IntegrationTests/NonSwaggerIntegrationTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/NonSwaggerIntegrationTests.cs
@@ -11,15 +11,16 @@ using Xunit;
 
 namespace Microsoft.HttpRepl.IntegrationTests
 {
-    public class SwaggerIntegrationTests : BaseIntegrationTest, IClassFixture<HttpCommandsFixture<SampleApiServerConfig>>
+    public class NonSwaggerIntegrationTests : BaseIntegrationTest, IClassFixture<HttpCommandsFixture<NonSwaggerSampleApiServerConfig>>
     {
-        private readonly SampleApiServerConfig _serverConfig;
+        private readonly NonSwaggerSampleApiServerConfig _serverConfig;
 
-        public SwaggerIntegrationTests(HttpCommandsFixture<SampleApiServerConfig> fixture)
+        public NonSwaggerIntegrationTests(HttpCommandsFixture<NonSwaggerSampleApiServerConfig> fixture)
         {
             _serverConfig = fixture.Config;
+            _serverConfig.EnableSwagger = false;
         }
-        
+
         [Fact]
         public async Task ListCommand_WithSwagger_ShowsAvailableSubpaths()
         {
@@ -41,19 +42,12 @@ ls";
 
             // make sure to normalize newlines in the expected output
             string expected = NormalizeOutput(@"(Disconnected)~ set base [BaseUrl]
-Using swagger metadata from [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/~ ls
-.     []
-api   []
 
 [BaseUrl]/~ cd api
-/api    []
 
 [BaseUrl]/api~ ls
-.        []
-..       []
-Values   [post]
 
 [BaseUrl]/api~", null);
 
@@ -77,19 +71,22 @@ ls";
             output = NormalizeOutput(output, _serverConfig.BaseAddress);
 
             string expected = NormalizeOutput(@"(Disconnected)~ set base [BaseUrl]
-Using swagger metadata from [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/~ cd api/Values
-/api/Values    [post]
 
 [BaseUrl]/api/Values~ ls
-.      [post]
-..     []
-{id}   [put]
 
 [BaseUrl]/api/Values~", null);
 
             Assert.Equal(expected, output);
+        }
+    }
+
+    public class NonSwaggerSampleApiServerConfig : SampleApiServerConfig
+    {
+        public NonSwaggerSampleApiServerConfig()
+        {
+            EnableSwagger = false;
         }
     }
 }

--- a/src/Microsoft.HttpRepl.IntegrationTests/SampleApi/SampleApiServer.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/SampleApi/SampleApiServer.cs
@@ -21,10 +21,13 @@ namespace Microsoft.HttpRepl.IntegrationTests.SampleApi
                            .ConfigureServices(services =>
                            {
                                services.AddControllers();
-                               services.AddSwaggerGen(c =>
+                               if (config.EnableSwagger)
                                {
-                                   c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
-                               });
+                                   services.AddSwaggerGen(c =>
+                                   {
+                                       c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
+                                   });
+                               }
                            })
                            .Configure(app =>
                            {
@@ -36,7 +39,10 @@ namespace Microsoft.HttpRepl.IntegrationTests.SampleApi
                                IRouter routes = routeBuilder.Build();
                                app.UseRouter(routes);
 
-                               app.UseSwagger();
+                               if (config.EnableSwagger)
+                               {
+                                   app.UseSwagger();
+                               }
                            })
                            .Build();
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/SampleApi/SampleApiServerConfig.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/SampleApi/SampleApiServerConfig.cs
@@ -15,6 +15,11 @@ namespace Microsoft.HttpRepl.IntegrationTests.SampleApi
         public string BaseAddress => $"http://localhost:{Port}";
         public Lazy<int> Port { get; set; } = new Lazy<int>(() => FindFreeTcpPort());
 
+        /// <summary>
+        /// Turns Swagger on or off for the SampleApiServer instance.
+        /// </summary>
+        public bool EnableSwagger { get; set; } = true;
+
         public Collection<SampleApiServerRoute> Routes { get; } = new Collection<SampleApiServerRoute>();
 
         private static int FindFreeTcpPort()


### PR DESCRIPTION
This adds a flag to the test fixture to toggle whether the Swagger
endpoint is active, which allows tests to be written with it on or off.

Still to do: find a way to toggle it on each test run.  Ideally, we
would have a single Theory test which would take as inputs whether the
Swagger endpoint is active, and the corresponding expected output.
Currently the tests have to be separate because the server is started
during Fixture initialization, which is before the test method receives
control.