### PR TITLE
Change logic for modifying TTY settings on linux so that character duplication does not occur.

### DIFF
--- a/src/Microsoft.Repl/Input/InputManager.cs
+++ b/src/Microsoft.Repl/Input/InputManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -113,13 +114,12 @@ namespace Microsoft.Repl.Input
         private void StashEchoState()
         {
             string sttyFlags = null;
-            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 _ttyState = GetTtyState();
                 sttyFlags = "gfmt1:erase=08:werase=08 -echo -icanon";
             }
-            //If it's any of the ubuntu variants on 18.x, stty tweaks are required
-            else if (System.Runtime.InteropServices.RuntimeInformation.OSDescription.IndexOf("buntu", StringComparison.OrdinalIgnoreCase) > -1)
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 _ttyState = GetTtyState();
                 sttyFlags = "erase 0x08 werase 0x08 -echo -icanon";


### PR DESCRIPTION
A quick fix for the detection logic for determining if we need to update the TTY settings, addressing part of #15. 

I put in a separate issue https://github.com/aspnet/HttpRepl/issues/72 to track the tests that need to be written against the whole InputManager class, because I didn't want those to block this simple fix getting in.