### PR TITLE
Refactor ICoreParseResult section checking

### DIFF
--- a/src/Microsoft.HttpRepl/Commands/ClearCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ClearCommand.cs
@@ -18,7 +18,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public bool? CanHandle(IShellState shellState, object programState, ICoreParseResult parseResult)
         {
-            return parseResult.Sections.Count == 1 && (string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase) || string.Equals(parseResult.Sections[0], AlternateName, StringComparison.OrdinalIgnoreCase))
+            return parseResult.ContainsExactly(Name) || parseResult.ContainsExactly(AlternateName)
                 ? (bool?) true
                 : null;
         }
@@ -32,7 +32,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public string GetHelpDetails(IShellState shellState, object programState, ICoreParseResult parseResult)
         {
-            if (parseResult.Sections.Count == 1 && (string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase) || string.Equals(parseResult.Sections[0], AlternateName, StringComparison.OrdinalIgnoreCase)))
+            if (parseResult.ContainsExactly(Name) || parseResult.ContainsExactly(AlternateName))
             {
                 return "Clears the shell";
             }

--- a/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
@@ -30,7 +30,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public bool? CanHandle(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
-            return parseResult.Sections.Count > 0 && string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase)
+            return parseResult.ContainsAtLeast(Name)
                 ? (bool?)true
                 : null;
         }
@@ -156,7 +156,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public string GetHelpDetails(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
-            if (parseResult.Sections.Count > 0 && string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase))
+            if (parseResult.ContainsAtLeast(Name))
             {
                 if (parseResult.Sections.Count > 1)
                 {
@@ -183,7 +183,7 @@ namespace Microsoft.HttpRepl.Commands
             {
                 return new[] { Name };
             }
-            else if (parseResult.Sections.Count > 1 && string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase))
+            else if (parseResult.ContainsAtLeast(minimumLength: 2, Name))
             {
                 if (shellState.CommandDispatcher is ICommandDispatcher<HttpState, ICoreParseResult> dispatcher 
                     && parseResult.Slice(1) is ICoreParseResult continuationParseResult)

--- a/src/Microsoft.HttpRepl/Commands/RunCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/RunCommand.cs
@@ -29,7 +29,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public bool? CanHandle(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
-            return parseResult.Sections.Count > 1 && parseResult.Sections.Count < 4 && string.Equals(Name, parseResult.Sections[0], StringComparison.OrdinalIgnoreCase)
+            return parseResult.ContainsAtLeast(minimumLength: 2, Name) && parseResult.Sections.Count < 4
                 ? (bool?)true
                 : null;
         }
@@ -55,7 +55,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public string GetHelpDetails(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
-            if (parseResult.Sections.Count > 0 && string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase))
+            if (parseResult.ContainsAtLeast(Name))
             {
                 var helpText = new StringBuilder();
                 helpText.Append(Strings.Usage.Bold());

--- a/src/Microsoft.HttpRepl/Commands/SetBaseCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/SetBaseCommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public bool? CanHandle(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
-            return parseResult.Sections.Count > 1 && string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase) && string.Equals(parseResult.Sections[1], SubCommand, StringComparison.OrdinalIgnoreCase)
+            return parseResult.ContainsAtLeast(Name, SubCommand)
                 ? (bool?)true
                 : null;
         }
@@ -95,7 +95,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public string GetHelpDetails(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
-            if (parseResult.Sections.Count > 1 && string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase) && string.Equals(parseResult.Sections[1], SubCommand, StringComparison.OrdinalIgnoreCase))
+            if (parseResult.ContainsAtLeast(Name, SubCommand))
             {
                 var helpText = new StringBuilder();
                 helpText.Append(Strings.Usage.Bold());

--- a/src/Microsoft.HttpRepl/Commands/SetHeaderCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/SetHeaderCommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public bool? CanHandle(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
-            return parseResult.Sections.Count > 2 && string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase) && string.Equals(parseResult.Sections[1], SubCommand, StringComparison.OrdinalIgnoreCase)
+            return parseResult.ContainsAtLeast(minimumLength: 3, Name, SubCommand)
                 ? (bool?)true
                 : null;
         }
@@ -46,7 +46,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public string GetHelpDetails(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
-            if (parseResult.Sections.Count > 1 && string.Equals(parseResult.Sections[0], Name, StringComparison.Ordinal) && string.Equals(parseResult.Sections[1], SubCommand, StringComparison.OrdinalIgnoreCase))
+            if (parseResult.ContainsAtLeast(Name, SubCommand))
             {
                 var helpText = new StringBuilder();
                 helpText.Append(Strings.Usage.Bold());

--- a/src/Microsoft.HttpRepl/Commands/SetSwaggerCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/SetSwaggerCommand.cs
@@ -199,7 +199,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public string GetHelpDetails(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
-            if (parseResult.Sections.Count > 1 && string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase) && string.Equals(parseResult.Sections[1], SubCommand, StringComparison.OrdinalIgnoreCase))
+            if (parseResult.ContainsAtLeast(Name, SubCommand))
             {
                 return Description;
             }

--- a/src/Microsoft.HttpRepl/Commands/UICommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/UICommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public bool? CanHandle(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
-            return parseResult.Sections.Count == 1 && string.Equals(parseResult.Sections[0], Name)
+            return parseResult.ContainsExactly(Name)
                 ? (bool?)true
                 : null;
         }
@@ -45,7 +45,7 @@ namespace Microsoft.HttpRepl.Commands
 
         public string GetHelpDetails(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
-            if (parseResult.Sections.Count == 1 && string.Equals(parseResult.Sections[0], Name))
+            if (parseResult.ContainsExactly(Name))
             {
                 return Strings.UICommand_Description;
             }

--- a/src/Microsoft.Repl.Tests/Microsoft.Repl.Tests.csproj
+++ b/src/Microsoft.Repl.Tests/Microsoft.Repl.Tests.csproj
@@ -12,8 +12,4 @@
     <ProjectReference Include="..\Microsoft.Repl\Microsoft.Repl.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Parsing\" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.Repl.Tests/Microsoft.Repl.Tests.csproj
+++ b/src/Microsoft.Repl.Tests/Microsoft.Repl.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -10,6 +10,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Repl\Microsoft.Repl.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Parsing\" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Repl/Parsing/CoreParseResultExtensions.cs
+++ b/src/Microsoft.Repl/Parsing/CoreParseResultExtensions.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Repl.Parsing
+{
+    public static class CoreParseResultExtensions
+    {
+        public static bool ContainsExactly(this ICoreParseResult parseResult, int length, StringComparison stringComparison, params string[] sections)
+        {
+            if (parseResult.Sections.Count != length)
+            {
+                return false;
+            }
+
+            return CompareSections(parseResult.Sections, sections, stringComparison);
+        }
+
+        public static bool ContainsExactly(this ICoreParseResult parseResult, int length, params string[] sections)
+        {
+            return ContainsExactly(parseResult, length, StringComparison.OrdinalIgnoreCase, sections);
+        }
+
+        public static bool ContainsExactly(this ICoreParseResult parseResult, params string[] sections)
+        {
+            return ContainsExactly(parseResult, sections.Length, sections);
+        }
+
+        public static bool ContainsAtLeast(this ICoreParseResult parseResult, int minimumLength, StringComparison stringComparison, params string[] sections)
+        {
+            if (parseResult.Sections.Count < minimumLength)
+            {
+                return false;
+            }
+
+            return CompareSections(parseResult.Sections, sections, stringComparison);
+        }
+
+        public static bool ContainsAtLeast(this ICoreParseResult parseResult, int minimumLength, params string[] sections)
+        {
+            return ContainsAtLeast(parseResult, minimumLength, StringComparison.OrdinalIgnoreCase, sections);
+        }
+
+        public static bool ContainsAtLeast(this ICoreParseResult parseResult, params string[] sections)
+        {
+            return ContainsAtLeast(parseResult, minimumLength: sections.Length, sections);
+        }
+
+        private static bool CompareSections(IReadOnlyList<string> parseSections, string[] sections, StringComparison stringComparison)
+        {
+            for (int index = 0; index < sections.Length; index++)
+            {
+                if (!string.Equals(parseSections[index], sections[index], stringComparison))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.Repl/Parsing/CoreParseResultExtensions.cs
+++ b/src/Microsoft.Repl/Parsing/CoreParseResultExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Repl.Parsing
     {
         public static bool ContainsExactly(this ICoreParseResult parseResult, int length, StringComparison stringComparison, params string[] sections)
         {
-            if (parseResult.Sections.Count != length)
+            if (parseResult.Sections.Count != length || parseResult.Sections.Count < sections.Length)
             {
                 return false;
             }
@@ -30,7 +30,7 @@ namespace Microsoft.Repl.Parsing
 
         public static bool ContainsAtLeast(this ICoreParseResult parseResult, int minimumLength, StringComparison stringComparison, params string[] sections)
         {
-            if (parseResult.Sections.Count < minimumLength)
+            if (parseResult.Sections.Count < minimumLength || parseResult.Sections.Count < sections.Length)
             {
                 return false;
             }


### PR DESCRIPTION
Fixes #60 by introducing some extension methods for ICoreParseResult.

Originally, there was a lot of code such as:

```C#
bool canHandle = parseResult.Sections.Count == 2 && string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase) && string.Equals(parseResult.Sections[1], SubCommand, StringComparison.OrdinalIgnoreCase));
bool canHandle = parseResult.Sections.Count == 2 && string.Equals(parseResult.Sections[0], Name, StringComparison.OrdinalIgnoreCase) && string.Equals(parseResult.Sections[1], SubCommand, StringComparison.OrdinalIgnoreCase));
```

With this PR, those calls could be replaced with:
```C#
bool canHandle = parseResults.ContainsExactly(Name, SubCommand);
bool canHandle = parseResults.ContainsAtLeast(Name, SubCommand);
```
The simple forms of the method use the length of the arguments passed in along with a default of `StringComparison.OrdinalIgnoreCase` to find the result. There are overloads that allow you to specify those directly if necessary, however:

```C#
public static bool ContainsExactly(this ICoreParseResult parseResult, int length, StringComparison stringComparison, params string[] sections)
{
...
}
public static bool ContainsAtLeast(this ICoreParseResult parseResult, int minimumLength, StringComparison stringComparison, params string[] sections)
{
...
}
```
This is most commonly used (currently) when you want to  say something like "there must be at least two sections, but all I know is that the first one needs to be Name. So you'd do something like:

```C#
bool canHandle = parseResults.ContainsAtLeast(minimumLength: 2, Name);
```