### PR TITLE
Updating some test packages and adding an explicit reference to latest System.Net.Http to prevent security issues and warnings.

### DIFF
--- a/build/PackageVersions.targets
+++ b/build/PackageVersions.targets
@@ -6,8 +6,9 @@
   -->
   <ItemGroup>
     <PackageReference Update="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
-    <PackageReference Update="Moq" Version="4.10.1" PrivateAssets="All" />
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.1" PrivateAssets="All" />
+    <PackageReference Update="Moq" Version="4.12.0" PrivateAssets="All" />
+    <PackageReference Update="Newtonsoft.Json" Version="12.0.2" PrivateAssets="All" />
     <PackageReference Update="Swashbuckle.AspNetCore" Version="5.0.0-rc2" PrivateAssets="All" />
+    <PackageReference Update="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.HttpRepl.Fakes/Microsoft.HttpRepl.Fakes.csproj
+++ b/src/Microsoft.HttpRepl.Fakes/Microsoft.HttpRepl.Fakes.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Moq" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.HttpRepl.IntegrationTests/Microsoft.HttpRepl.IntegrationTests.csproj
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Microsoft.HttpRepl.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -13,6 +13,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.HttpRepl.Tests/Microsoft.HttpRepl.Tests.csproj
+++ b/src/Microsoft.HttpRepl.Tests/Microsoft.HttpRepl.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -9,6 +9,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Repl.Tests/Microsoft.Repl.Tests.csproj
+++ b/src/Microsoft.Repl.Tests/Microsoft.Repl.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Moq" />
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We are getting warnings about a downstream reference to a known vulnerable component (System.Net.Http v4.3.0). We're not actually using that here, but in order to get rid of the warnings, I'm adding an explicit reference to a newer version that is not vulnerable.