### PR TITLE
Addressing issues in OpenApiV3EndpointMetadataReader

### DIFF
--- a/src/Microsoft.HttpRepl.IntegrationTests/NonSwaggerIntegrationTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/NonSwaggerIntegrationTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.HttpRepl.IntegrationTests
         }
 
         [Fact]
-        public async Task ListCommand_WithSwagger_ShowsAvailableSubpaths()
+        public async Task ListCommand_WithoutSwagger_ShowsNoSubpaths()
         {
             string scriptText = $@"set base {_serverConfig.BaseAddress}
 ls
@@ -55,7 +55,7 @@ ls";
         }
 
         [Fact]
-        public async Task ListCommand_WithSwagger_ShowsControllerActionsWithHttpVerbs()
+        public async Task ListCommand_WithoutSwagger_ShowsNoActionsOrVerbs()
         {
             string scriptText = $@"set base {_serverConfig.BaseAddress}
 cd api/Values

--- a/src/Microsoft.HttpRepl.IntegrationTests/SwaggerIntegrationTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/SwaggerIntegrationTests.cs
@@ -52,7 +52,7 @@ api   []
 [BaseUrl]/api~ ls
 .        []
 ..       []
-Values   [post]
+Values   [get|post]
 
 [BaseUrl]/api~", null);
 
@@ -79,12 +79,12 @@ ls";
 Using swagger metadata from [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/~ cd api/Values
-/api/Values    [post]
+/api/Values    [get|post]
 
 [BaseUrl]/api/Values~ ls
-.      [post]
+.      [get|post]
 ..     []
-{id}   [put]
+{id}   [get|put|delete]
 
 [BaseUrl]/api/Values~", null);
 

--- a/src/Microsoft.HttpRepl.Tests/OpenApi/OpenApiV3EndpointMetadataReaderTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/OpenApi/OpenApiV3EndpointMetadataReaderTests.cs
@@ -112,6 +112,89 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
         }
 
         [Fact]
+        public void ReadMetadata_WithContentAndOneContentType_ReturnsEndpointMetadataWithContentType()
+        {
+            string json = @"{
+  ""openapi"": ""3.0.0"",
+  ""paths"": {
+    ""/pets"": {
+      ""post"": {
+        ""summary"": ""Create a pet"",
+        ""operationId"": ""createPets"",
+        ""responses"": {
+          ""201"": {
+            ""description"": ""Null response""
+          }
+        },
+        ""requestBody"": {
+          ""description"": ""A Request Body"",
+          ""required"": false,
+          ""content"": {
+            ""application/json"": {
+            }
+          }
+        }
+      }
+    }
+  }
+}";
+            JObject jobject = JObject.Parse(json);
+            OpenApiV3EndpointMetadataReader openApiV3EndpointMetadataReader = new OpenApiV3EndpointMetadataReader();
+
+            List<EndpointMetadata> endpointMetadata = openApiV3EndpointMetadataReader.ReadMetadata(jobject).ToList();
+
+            Assert.Single(endpointMetadata);
+            Assert.Equal("/pets", endpointMetadata[0].Path);
+            Assert.Single(endpointMetadata[0].AvailableRequests);
+            Assert.True(endpointMetadata[0].AvailableRequests.ContainsKey("post"));
+            Assert.Single(endpointMetadata[0].AvailableRequests["post"]);
+            Assert.True(endpointMetadata[0].AvailableRequests["post"].ContainsKey("application/json"));
+        }
+
+        [Fact]
+        public void ReadMetadata_WithContentAndMultipleContentTypes_ReturnsEndpointMetadataWithContentTypes()
+        {
+            string json = @"{
+  ""openapi"": ""3.0.0"",
+  ""paths"": {
+    ""/pets"": {
+      ""post"": {
+        ""summary"": ""Create a pet"",
+        ""operationId"": ""createPets"",
+        ""responses"": {
+          ""201"": {
+            ""description"": ""Null response""
+          }
+        },
+        ""requestBody"": {
+          ""description"": ""A Request Body"",
+          ""required"": false,
+          ""content"": {
+            ""application/json"": {
+            },
+            ""text/plain"": {
+            }
+          }
+        }
+      }
+    }
+  }
+}";
+            JObject jobject = JObject.Parse(json);
+            OpenApiV3EndpointMetadataReader openApiV3EndpointMetadataReader = new OpenApiV3EndpointMetadataReader();
+
+            List<EndpointMetadata> endpointMetadata = openApiV3EndpointMetadataReader.ReadMetadata(jobject).ToList();
+
+            Assert.Single(endpointMetadata);
+            Assert.Equal("/pets", endpointMetadata[0].Path);
+            Assert.Single(endpointMetadata[0].AvailableRequests);
+            Assert.True(endpointMetadata[0].AvailableRequests.ContainsKey("post"));
+            Assert.Equal(2, endpointMetadata[0].AvailableRequests["post"].Count);
+            Assert.True(endpointMetadata[0].AvailableRequests["post"].ContainsKey("application/json"));
+            Assert.True(endpointMetadata[0].AvailableRequests["post"].ContainsKey("text/plain"));
+        }
+
+        [Fact]
         public void ReadMetadata_WithValidInput_ReturnsEndpointMetadata()
         {
             string json = @"{

--- a/src/Microsoft.HttpRepl.Tests/OpenApi/OpenApiV3EndpointMetadataReaderTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/OpenApi/OpenApiV3EndpointMetadataReaderTests.cs
@@ -48,7 +48,36 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
         }
 
         [Fact]
-        public void ReadMetadata_WithNoRequestBody_ReturnsEndpointMetadataWithEmptyAvailableRequests()
+        public void ReadMetadata_WithNoResponses_ReturnsEndpointMetadataWithEmptyAvailableRequests()
+        {
+            string json = @"{
+  ""openapi"": ""3.0.0"",
+  ""paths"": {
+    ""/pets"": {
+      ""post"": {
+        ""summary"": ""Create a pet"",
+        ""operationId"": ""createPets"",
+        ""requestBody"": {
+          ""content"": {
+
+          }
+        }
+      }
+    }
+  }
+}";
+            JObject jobject = JObject.Parse(json);
+            OpenApiV3EndpointMetadataReader openApiV3EndpointMetadataReader = new OpenApiV3EndpointMetadataReader();
+
+            List<EndpointMetadata> endpointMetadata = openApiV3EndpointMetadataReader.ReadMetadata(jobject).ToList();
+
+            Assert.Single(endpointMetadata);
+            Assert.Equal("/pets", endpointMetadata[0].Path);
+            Assert.Empty(endpointMetadata[0].AvailableRequests);
+        }
+
+        [Fact]
+        public void ReadMetadata_WithNoContent_ReturnsEndpointMetadataWithRequestButNoContentTypes()
         {
             string json = @"{
   ""openapi"": ""3.0.0"",
@@ -61,37 +90,10 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
           ""201"": {
             ""description"": ""Null response""
           }
-        }
-      }
-    }
-  }
-}";
-            JObject jobject = JObject.Parse(json);
-            OpenApiV3EndpointMetadataReader openApiV3EndpointMetadataReader = new OpenApiV3EndpointMetadataReader();
-
-            List<EndpointMetadata> endpointMetadata = openApiV3EndpointMetadataReader.ReadMetadata(jobject).ToList();
-
-            Assert.Single(endpointMetadata);
-            Assert.Equal("/pets", endpointMetadata[0].Path);
-            Assert.Empty(endpointMetadata[0].AvailableRequests);
-        }
-
-        [Fact]
-        public void ReadMetadata_WithNoContent_ReturnsEndpointMetadataWithEmptyAvailableRequests()
-        {
-            string json = @"{
-  ""openapi"": ""3.0.0"",
-  ""paths"": {
-    ""/pets"": {
-      ""post"": {
+        },
         ""requestBody"": {
-          ""summary"": ""Create a pet"",
-          ""operationId"": ""createPets"",
-          ""responses"": {
-            ""201"": {
-              ""description"": ""Null response""
-            }
-          }
+          ""description"": ""A Request Body"",
+          ""required"": false
         }
       }
     }
@@ -104,7 +106,9 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             Assert.Single(endpointMetadata);
             Assert.Equal("/pets", endpointMetadata[0].Path);
-            Assert.Empty(endpointMetadata[0].AvailableRequests);
+            Assert.Single(endpointMetadata[0].AvailableRequests);
+            Assert.True(endpointMetadata[0].AvailableRequests.ContainsKey("post"));
+            Assert.Empty(endpointMetadata[0].AvailableRequests["post"]);
         }
 
         [Fact]
@@ -115,39 +119,82 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
   ""paths"": {
     ""/pets"": {
       ""get"": {
-        ""requestBody"": {
-          ""content"": {
-            ""summary"": ""List all pets"",
-            ""operationId"": ""listPets"",
-            ""parameters"": [
-              {
-                ""name"": ""limit"",
-                ""in"": ""query"",
-                ""required"": false,
-                ""schema"": {
-                  ""type"": ""integer"",
-                  ""format"": ""int32""
-                }
-              }
-            ],
-            ""responses"": {
-              ""200"": {
-                ""description"": ""An paged array of pets""
-              }
+        ""summary"": ""List all pets"",
+        ""operationId"": ""listPets"",
+        ""parameters"": [
+          {
+            ""name"": ""limit"",
+            ""in"": ""query"",
+            ""required"": false,
+            ""schema"": {
+              ""type"": ""integer"",
+              ""format"": ""int32""
             }
+          }
+        ],
+        ""responses"": {
+          ""200"": {
+            ""description"": ""An paged array of pets""
           }
         }
       },
       ""post"": {
+        ""summary"": ""Create a pet"",
+        ""operationId"": ""createPets"",
+        ""responses"": {
+          ""201"": {
+            ""description"": ""Null response""
+          }
+        },
         ""requestBody"": {
           ""content"": {
-            ""summary"": ""Create a pet"",
-            ""operationId"": ""createPets"",
-            ""responses"": {
-              ""201"": {
-                ""description"": ""Null response""
-              }
-            }
+            
+          }
+        }
+      }
+    }
+  }
+}";
+            JObject jobject = JObject.Parse(json);
+            OpenApiV3EndpointMetadataReader openApiV3EndpointMetadataReader = new OpenApiV3EndpointMetadataReader();
+
+            List<EndpointMetadata> endpointMetadata = openApiV3EndpointMetadataReader.ReadMetadata(jobject).ToList();
+
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, IReadOnlyList<Parameter>>> availableRequests = endpointMetadata[0].AvailableRequests;
+
+            Assert.Single(endpointMetadata);
+            Assert.Equal("/pets", endpointMetadata[0].Path);
+
+            Assert.Equal(2, availableRequests.Count);
+            Assert.True(availableRequests.ContainsKey("get"));
+            Assert.True(availableRequests.ContainsKey("post"));
+        }
+
+        [Fact]
+        public void ReadMetadata_WithNoRequestBody_ReturnsEndpointMetadata()
+        {
+            string json = @"{
+  ""openapi"": ""3.0.0"",
+  ""paths"": {
+    ""/pets"": {
+      ""get"": {
+        ""responses"": {
+          ""200"": {
+            ""description"": ""Success""
+          }
+        }
+      },
+      ""post"": {
+        ""summary"": ""Create a pet"",
+        ""operationId"": ""createPets"",
+        ""responses"": {
+          ""201"": {
+            ""description"": ""Null response""
+          }
+        },
+        ""requestBody"": {
+          ""content"": {
+            
           }
         }
       }

--- a/src/Microsoft.HttpRepl/OpenApi/OpenApiV3EndpointMetadataReader.cs
+++ b/src/Microsoft.HttpRepl/OpenApi/OpenApiV3EndpointMetadataReader.cs
@@ -15,6 +15,7 @@ namespace Microsoft.HttpRepl.OpenApi
             return (document["openapi"]?.ToString() ?? "").StartsWith("3.", StringComparison.Ordinal);
         }
 
+        // Based on latest spec at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md
         public IEnumerable<EndpointMetadata> ReadMetadata(JObject document)
         {
             List<EndpointMetadata> metadata = new List<EndpointMetadata>();

--- a/src/Microsoft.HttpRepl/OpenApi/OpenApiV3EndpointMetadataReader.cs
+++ b/src/Microsoft.HttpRepl/OpenApi/OpenApiV3EndpointMetadataReader.cs
@@ -36,6 +36,15 @@ namespace Microsoft.HttpRepl.OpenApi
 
                         if (method.Value is JObject methodBody)
                         {
+                            if (!(methodBody["responses"] is JObject))
+                            {
+                                // responses is the only required part of an Operation Object
+                                // so if this is missing, we'll skip this operation
+                                continue;
+                            }
+
+                            requestMethods[method.Name] = new Dictionary<string, IReadOnlyList<Parameter>>(StringComparer.OrdinalIgnoreCase);
+
                             if (methodBody["parameters"] is JArray parametersArray)
                             {
                                 foreach (JObject parameterObj in parametersArray.OfType<JObject>())


### PR DESCRIPTION
As I started doing additional integration tests yesterday, I realized that the V3 metadata reader was not handling most of the GET endpoints in our sample api server. For example, our sample api server includes an `HttpGet` route for `api/values`, but the current output of our swagger integration tests shows that it's not being picked up:

```
[BaseUrl]/api~ ls
.        []
..       []
Values   [post]
```

Digging a little further, it seems that the `ReadMetadata` method on `OpenApiV3EndpointMetadataReader` would only add a request method to the collection if it had a request body. Even before reading the spec, I realized that couldn't be right - `GET` apis aren't going to have a request body. And indeed, in our sample api swagger endpoint, the `GET` apis didn't have `requestBody` properties.

So that led me down the path of reading the OpenApi V3 spec, which you can find [here](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md) and [here](https://swagger.io/specification/). 

It turns out that for a request method (referred to in the spec as an operation), only the `responses` property is required and `requestBody` is optional:

`responses`:
> **REQUIRED**. The list of possible responses as they are returned from executing this operation.

`requestBody`:
> The request body applicable for this operation. The requestBody is only supported in HTTP methods where the HTTP 1.1 specification RFC7231 has explicitly defined semantics for request bodies. In other cases where the HTTP spec is vague, requestBody SHALL be ignored by consumers.

 The `content` property of the `requestBody` is required if the `requestBody` is present, but that doesn't make the `requestBody` required.

`content`:
> **REQUIRED**. The content of the request body. The key is a media type or media type range and the value describes it. For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*

So, given all that, we have some choices to make in the code. For starters:

1. What do we do with the rest of the information in a particular `operation`/`requestMethod` if it has no `responses` property? We don't _need_ the `responses` property for what we're doing right now. But not having it would make it an invalid `operation`.
2. What do we do with the rest of the information in a particular `operation`/`requestMethod` if the `requestBody` property doesn't have a `content` property? We need the `content` property to populate the allowed content types, but we don't need it to be able to say the endpoint exists or that the `operation`/`requestMethod` exists.

In this PR, I went with the more restrictive answer to 1 (if there's no `responses` property, just skip that `operation` altogether, regardless of whatever else is there) and the more permissive answer to 2 (if there's no `content` property, leave the `operation` in place, but just don't have any allowed content types.

Happy to discuss a different set of answers if others disagree.

Along the way in this PR I also ended up changing some of the test data in the `OpenApiV3EndpointMetadataReaderTests` class because it was invalid. Mostly, this was a case of the `summary`, `operationId` and `responses` properties being inside `content` instead of inside the `operation` where they should be.