### PR TITLE
Add a PackageIconUrl for the Nuget package

### DIFF
--- a/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
+++ b/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
@@ -8,6 +8,7 @@
     <PackageId>Microsoft.dotnet-httprepl</PackageId>
     <PackageTags>dotnet;http;httprepl</PackageTags>
     <PackageProjectUrl>https://aka.ms/http-repl-doc</PackageProjectUrl>
+    <PackageIconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
 
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
This URL points to the ".NET" icon that's used for other Microsoft global tools and packages.