### PR TITLE
Refactored BaseHttpCommand and added couple of tests to verify format behavior

### DIFF
--- a/src/Microsoft.HttpRepl.Fakes/MockHttpMessageHandler.cs
+++ b/src/Microsoft.HttpRepl.Fakes/MockHttpMessageHandler.cs
@@ -11,6 +11,7 @@ namespace Microsoft.HttpRepl.Fakes
 {
     public class MockHttpMessageHandler : HttpMessageHandler
     {
+        private readonly string _contentType;
         private readonly string _fileContents;
         private readonly string _header;
         private readonly bool _readFromFile;
@@ -19,8 +20,10 @@ namespace Microsoft.HttpRepl.Fakes
         public MockHttpMessageHandler(IDictionary<string, string> urlsWithResponse,
             string header,
             bool readFromFile,
-            string fileContents)
+            string fileContents,
+            string contentType)
         {
+            _contentType = contentType;
             _fileContents = fileContents;
             _header = header;
             _readFromFile = readFromFile;
@@ -45,6 +48,11 @@ namespace Microsoft.HttpRepl.Fakes
             else
             {
                 httpResponseMessage.Content = new MockHttpContent(responseContent);
+            }
+
+            if (!string.IsNullOrEmpty(_contentType) && httpResponseMessage.Content != null)
+            {
+                httpResponseMessage.Content.Headers.Add("Content-Type", _contentType);
             }
 
             return Task.FromResult(httpResponseMessage);

--- a/src/Microsoft.HttpRepl.Fakes/MockHttpMessageHandler.cs
+++ b/src/Microsoft.HttpRepl.Fakes/MockHttpMessageHandler.cs
@@ -36,6 +36,7 @@ namespace Microsoft.HttpRepl.Fakes
             _urlsWithResponse.TryGetValue(absoluteUri, out string responseContent);
 
             HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+            httpResponseMessage.RequestMessage = request;
 
             if (_readFromFile)
             {

--- a/src/Microsoft.HttpRepl.Tests/Commands/CommandTestsBase.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/CommandTestsBase.cs
@@ -42,7 +42,8 @@ namespace Microsoft.HttpRepl.Tests.Commands
             out IPreferences preferences,
             string header = "",
             bool readBodyFromFile = false,
-            string fileContents = "")
+            string fileContents = "",
+            string contentType = "")
         {
             parseResult = CoreParseResultHelper.Create(commandText);
             shellState = new MockedShellState();
@@ -54,7 +55,8 @@ namespace Microsoft.HttpRepl.Tests.Commands
                 path,
                 urlsWithResponse,
                 readBodyFromFile,
-                fileContents);
+                fileContents,
+                contentType);
         }
 
         protected static void VerifyErrorMessageWasWrittenToConsoleManagerError(IShellState shellState)
@@ -71,11 +73,12 @@ namespace Microsoft.HttpRepl.Tests.Commands
             string path = "",
             IDictionary<string, string> urlsWithResponse = null,
             bool readFromFile = false,
-            string fileContents = "")
+            string fileContents = "",
+            string contentType = "")
         {
             HttpResponseMessage responseMessage = new HttpResponseMessage();
             responseMessage.Content = new MockHttpContent(string.Empty);
-            MockHttpMessageHandler messageHandler = new MockHttpMessageHandler(urlsWithResponse, header, readFromFile, fileContents);
+            MockHttpMessageHandler messageHandler = new MockHttpMessageHandler(urlsWithResponse, header, readFromFile, fileContents, contentType);
             HttpClient httpClient = new HttpClient(messageHandler);
             fileSystem = new MockedFileSystem();
             preferences = new NullPreferences();

--- a/src/Microsoft.HttpRepl.Tests/Commands/GetCommandTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/GetCommandTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
         [Fact]
         public async Task ExecuteAsync_WithJsonContentTypeInHeader_FormatsResponseContent()
         {
-            string response = @"{
+            string json = @"{
 ""swagger"": ""2.0"",
 ""info"": {
 ""version"": ""v1""
@@ -113,7 +113,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
 }";
             string path  = "this/is/a/test/route/for/formatting";
 
-            _urlsWithResponse.Add(_baseAddress + path, response);
+            _urlsWithResponse.Add(_baseAddress + path, json);
 
             ArrangeInputs(commandText: "GET",
                 baseAddress: _baseAddress,
@@ -141,8 +141,9 @@ namespace Microsoft.HttpRepl.Tests.Commands
 }";
             List<string> result = shellState.Output;
 
-            Assert.Equal(2, result.Count);
+            Assert.Equal(3, result.Count);
             Assert.Contains("HTTP/1.1 200 OK", result);
+            Assert.Contains("Content-Type: application/json", result);
             Assert.Contains(expectedResponse, result);
         }
     }

--- a/src/Microsoft.HttpRepl.Tests/Commands/GetCommandTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/GetCommandTests.cs
@@ -146,5 +146,36 @@ namespace Microsoft.HttpRepl.Tests.Commands
             Assert.Contains("Content-Type: application/json", result);
             Assert.Contains(expectedResponse, result);
         }
+
+        [Fact]
+        public async Task ExecuteAsync_WithTextContentType_DoesNotFormatResponseContent()
+        {
+            string unformattedResponse = "This is an        unformatted response.      ";
+
+            string path = "this/is/a/test/route/for/formatting";
+
+            _urlsWithResponse.Add(_baseAddress + path, unformattedResponse);
+
+            ArrangeInputs(commandText: "GET",
+                baseAddress: _baseAddress,
+                path: path,
+                urlsWithResponse: _urlsWithResponse,
+                out MockedShellState shellState,
+                out HttpState httpState,
+                out ICoreParseResult parseResult,
+                out MockedFileSystem fileSystem,
+                out IPreferences preferences,
+                contentType: "text/plain");
+
+            GetCommand getCommand = new GetCommand(fileSystem, preferences);
+            await getCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            List<string> result = shellState.Output;
+
+            Assert.Equal(3, result.Count);
+            Assert.Contains("HTTP/1.1 200 OK", result);
+            Assert.Contains("Content-Type: text/plain", result);
+            Assert.Contains(unformattedResponse, result);
+        }
     }
 }

--- a/src/Microsoft.HttpRepl.Tests/Commands/GetCommandTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/GetCommandTests.cs
@@ -97,5 +97,53 @@ namespace Microsoft.HttpRepl.Tests.Commands
             Assert.Contains("HTTP/1.1 200 OK", result);
             Assert.Contains(expectedResponse, result);
         }
+
+        [Fact]
+        public async Task ExecuteAsync_WithJsonContentTypeInHeader_FormatsResponseContent()
+        {
+            string response = @"{
+""swagger"": ""2.0"",
+""info"": {
+""version"": ""v1""
+},
+""paths"": {
+""/api/Employees"": {
+}
+}
+}";
+            string path  = "this/is/a/test/route/for/formatting";
+
+            _urlsWithResponse.Add(_baseAddress + path, response);
+
+            ArrangeInputs(commandText: "GET",
+                baseAddress: _baseAddress,
+                path: path,
+                urlsWithResponse: _urlsWithResponse,
+                out MockedShellState shellState,
+                out HttpState httpState,
+                out ICoreParseResult parseResult,
+                out MockedFileSystem fileSystem,
+                out IPreferences preferences,
+                contentType: "application/json");
+
+            GetCommand getCommand = new GetCommand(fileSystem, preferences);
+            await getCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            string expectedResponse = @"{
+  ""swagger"": ""2.0"",
+  ""info"": {
+    ""version"": ""v1""
+  },
+  ""paths"": {
+    ""/api/Employees"": {
+    }
+  }
+}";
+            List<string> result = shellState.Output;
+
+            Assert.Equal(2, result.Count);
+            Assert.Contains("HTTP/1.1 200 OK", result);
+            Assert.Contains(expectedResponse, result);
+        }
     }
 }

--- a/src/Microsoft.HttpRepl.Tests/Commands/GetCommandTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/GetCommandTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
         }
 
         [Fact]
-        public async Task ExecuteAsync_WithTextContentType_DoesNotFormatResponseContent()
+        public async Task ExecuteAsync_WithTextContentTypeInHeader_DoesNotFormatResponseContent()
         {
             string unformattedResponse = "This is an        unformatted response.      ";
 

--- a/src/Microsoft.HttpRepl.Tests/Commands/GetCommandTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/GetCommandTests.cs
@@ -70,8 +70,8 @@ namespace Microsoft.HttpRepl.Tests.Commands
             List<string> result = shellState.Output;
 
             Assert.Equal(2, result.Count);
-            Assert.Contains("HTTP/1.1 200 OK", result);
-            Assert.Contains(expectedResponse, result);
+            Assert.Equal("HTTP/1.1 200 OK", result[0]);
+            Assert.Equal(expectedResponse, result[1]);
         }
 
         [Fact]
@@ -94,8 +94,8 @@ namespace Microsoft.HttpRepl.Tests.Commands
             List<string> result = shellState.Output;
 
             Assert.Equal(2, result.Count);
-            Assert.Contains("HTTP/1.1 200 OK", result);
-            Assert.Contains(expectedResponse, result);
+            Assert.Equal("HTTP/1.1 200 OK", result[0]);
+            Assert.Equal(expectedResponse, result[1]);
         }
 
         [Fact]
@@ -142,9 +142,9 @@ namespace Microsoft.HttpRepl.Tests.Commands
             List<string> result = shellState.Output;
 
             Assert.Equal(3, result.Count);
-            Assert.Contains("HTTP/1.1 200 OK", result);
-            Assert.Contains("Content-Type: application/json", result);
-            Assert.Contains(expectedResponse, result);
+            Assert.Equal("HTTP/1.1 200 OK", result[0]);
+            Assert.Equal("Content-Type: application/json", result[1]);
+            Assert.Equal(expectedResponse, result[2]);
         }
 
         [Fact]
@@ -173,9 +173,9 @@ namespace Microsoft.HttpRepl.Tests.Commands
             List<string> result = shellState.Output;
 
             Assert.Equal(3, result.Count);
-            Assert.Contains("HTTP/1.1 200 OK", result);
-            Assert.Contains("Content-Type: text/plain", result);
-            Assert.Contains(unformattedResponse, result);
+            Assert.Equal("HTTP/1.1 200 OK", result[0]);
+            Assert.Equal("Content-Type: text/plain", result[1]);
+            Assert.Equal(unformattedResponse, result[2]);
         }
     }
 }

--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -459,12 +459,10 @@ namespace Microsoft.HttpRepl.Commands
                     }
                 }
             }
-            else
-            {
-                string responseContent = await content.ReadAsStringAsync().ConfigureAwait(false);
-                bodyFileOutput?.Add(responseContent);
-                consoleManager.WriteLine(responseContent);
-            }
+
+            string responseContent = await content.ReadAsStringAsync().ConfigureAwait(false);
+            bodyFileOutput?.Add(responseContent);
+            consoleManager.WriteLine(responseContent);
         }
 
         private static async Task<bool> WaitForCompletionAsync(ValueTask<int> readTask, CancellationToken cancellationToken)

--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -64,7 +64,7 @@ namespace Microsoft.HttpRepl.Commands
 
                 CommandInputSpecificationBuilder builder = CommandInputSpecification.Create(Verb)
                     .MaximumArgCount(1)
-                    .WithOption(new CommandOptionSpecification(HeaderOption, requiresValue: true, forms: new[] {"--header", "-h"}))
+                    .WithOption(new CommandOptionSpecification(HeaderOption, requiresValue: true, forms: new[] { "--header", "-h" }))
                     .WithOption(new CommandOptionSpecification(ResponseFileOption, requiresValue: true, maximumOccurrences: 1, forms: new[] { "--response", }))
                     .WithOption(new CommandOptionSpecification(ResponseHeadersFileOption, requiresValue: true, maximumOccurrences: 1, forms: new[] { "--response:headers", }))
                     .WithOption(new CommandOptionSpecification(ResponseBodyFileOption, requiresValue: true, maximumOccurrences: 1, forms: new[] { "--response:body", }))
@@ -74,8 +74,8 @@ namespace Microsoft.HttpRepl.Commands
                 if (RequiresBody)
                 {
                     builder = builder.WithOption(new CommandOptionSpecification(NoBodyOption, maximumOccurrences: 1, forms: "--no-body"))
-                        .WithOption(new CommandOptionSpecification(BodyFileOption, requiresValue: true, maximumOccurrences: 1, forms: new[] {"--file", "-f"}))
-                        .WithOption(new CommandOptionSpecification(BodyContentOption, requiresValue: true, maximumOccurrences: 1, forms: new[] {"--content", "-c"}));
+                        .WithOption(new CommandOptionSpecification(BodyFileOption, requiresValue: true, maximumOccurrences: 1, forms: new[] { "--file", "-f" }))
+                        .WithOption(new CommandOptionSpecification(BodyContentOption, requiresValue: true, maximumOccurrences: 1, forms: new[] { "--content", "-c" }));
                 }
 
                 _inputSpec = builder.Finish();
@@ -194,10 +194,10 @@ namespace Microsoft.HttpRepl.Commands
                     contentType = "application/json";
                 }
 
-                byte[] data = noBody 
-                    ? new byte[0] 
-                    : string.IsNullOrEmpty(bodyContent) 
-                        ? _fileSystem.ReadAllBytesFromFile(filePath) 
+                byte[] data = noBody
+                    ? new byte[0]
+                    : string.IsNullOrEmpty(bodyContent)
+                        ? _fileSystem.ReadAllBytesFromFile(filePath)
                         : Encoding.UTF8.GetBytes(bodyContent);
 
                 HttpContent content = new ByteArrayContent(data);
@@ -388,6 +388,20 @@ namespace Microsoft.HttpRepl.Commands
                 return;
             }
 
+            await FormatResponseContentAsync(commandInput, programState, consoleManager, content, bodyFileOutput, preferences);
+
+            string responseContent = await content.ReadAsStringAsync().ConfigureAwait(false);
+            bodyFileOutput?.Add(responseContent);
+            consoleManager.WriteLine(responseContent);
+        }
+
+        private static async Task FormatResponseContentAsync(DefaultCommandInput<ICoreParseResult> commandInput,
+            HttpState programState,
+            IConsoleManager consoleManager,
+            HttpContent content,
+            List<string> bodyFileOutput,
+            IPreferences preferences)
+        {
             string contentType = null;
             if (content.Headers.TryGetValues("Content-Type", out IEnumerable<string> contentTypeValues))
             {
@@ -423,10 +437,6 @@ namespace Microsoft.HttpRepl.Commands
                     }
                 }
             }
-
-            string responseContent = await content.ReadAsStringAsync().ConfigureAwait(false);
-            bodyFileOutput?.Add(responseContent);
-            consoleManager.WriteLine(responseContent);
         }
 
         private static async Task<bool> WaitForCompletionAsync(ValueTask<int> readTask, CancellationToken cancellationToken)

--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -116,7 +116,7 @@ namespace Microsoft.HttpRepl.Commands
 
             if (RequiresBody)
             {
-                HandleBodyRequiresBody(commandInput, shellState, programState, request, thisRequestHeaders);
+                HandleRequiresBody(commandInput, shellState, programState, request, thisRequestHeaders);
             }
 
             foreach (KeyValuePair<string, IEnumerable<string>> header in programState.Headers)
@@ -146,11 +146,11 @@ namespace Microsoft.HttpRepl.Commands
             }
         }
 
-        private void HandleBodyRequiresBody(DefaultCommandInput<ICoreParseResult> commandInput,
-        IShellState shellState,
-        HttpState programState,
-        HttpRequestMessage request,
-        Dictionary<string, string> requestHeaders)
+        private void HandleRequiresBody(DefaultCommandInput<ICoreParseResult> commandInput,
+            IShellState shellState,
+            HttpState programState,
+            HttpRequestMessage request,
+            Dictionary<string, string> requestHeaders)
         {
             string filePath = null;
             string bodyContent = null;
@@ -369,6 +369,7 @@ namespace Microsoft.HttpRepl.Commands
             consoleManager.WriteLine();
             consoleManager.WriteLine($"Response from {hostString}...".SetColor(requestConfig.AddressColor));
             consoleManager.WriteLine();
+
             foreach (string responseLine in responseOutput)
             {
                 consoleManager.WriteLine(responseLine);

--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -416,10 +416,6 @@ namespace Microsoft.HttpRepl.Commands
             }
 
             await FormatResponseContentAsync(commandInput, consoleManager, content, bodyFileOutput, preferences);
-
-            string responseContent = await content.ReadAsStringAsync().ConfigureAwait(false);
-            bodyFileOutput?.Add(responseContent);
-            consoleManager.WriteLine(responseContent);
         }
 
         private static async Task FormatResponseContentAsync(DefaultCommandInput<ICoreParseResult> commandInput,
@@ -462,6 +458,12 @@ namespace Microsoft.HttpRepl.Commands
                         return;
                     }
                 }
+            }
+            else
+            {
+                string responseContent = await content.ReadAsStringAsync().ConfigureAwait(false);
+                bodyFileOutput?.Add(responseContent);
+                consoleManager.WriteLine(responseContent);
             }
         }
 

--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -239,6 +239,11 @@ namespace Microsoft.HttpRepl.Commands
                 _fileSystem.DeleteFile(filePath);
             }
 
+            AddHttpContentHeaders(content, programState, requestHeaders);
+        }
+
+        private void AddHttpContentHeaders(HttpContent content, HttpState programState, Dictionary<string, string> requestHeaders)
+        {
             foreach (KeyValuePair<string, IEnumerable<string>> header in programState.Headers)
             {
                 content.Headers.TryAddWithoutValidation(header.Key, header.Value);

--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -261,7 +261,7 @@ namespace Microsoft.HttpRepl.Commands
 
             if (echoRequest)
             {
-                protocolInfo = await HandleEchoRequest(commandInput, consoleManager, programState, response, cancellationToken);
+                await HandleEchoRequest(commandInput, consoleManager, programState, response, cancellationToken);
             }
 
             ResponseConfig responseConfig = new ResponseConfig(_preferences);
@@ -329,7 +329,7 @@ namespace Microsoft.HttpRepl.Commands
             consoleManager.WriteLine();
         }
 
-        private async Task<string> HandleEchoRequest(DefaultCommandInput<ICoreParseResult> commandInput,
+        private async Task HandleEchoRequest(DefaultCommandInput<ICoreParseResult> commandInput,
             IConsoleManager consoleManager,
             HttpState programState,
             HttpResponseMessage response,
@@ -379,8 +379,6 @@ namespace Microsoft.HttpRepl.Commands
             {
                 consoleManager.WriteLine(responseLine);
             }
-
-            return protocolInfo;
         }
 
         private static async Task FormatBodyAsync(DefaultCommandInput<ICoreParseResult> commandInput, HttpState programState, IConsoleManager consoleManager, HttpContent content, List<string> bodyFileOutput, IPreferences preferences, CancellationToken cancellationToken)


### PR DESCRIPTION
As a part of this pr:
- Refactored BaseHttpCommand class to make it more readable
- Added couple of tests to verify format behavior based on content type
- I did not find more areas for testing as most of the areas are covered by Commands that implement the abstract methods. Let me know if you have any suggestions around adding more tests