### PR TITLE
Remove colors in integration tests

### DIFF
--- a/src/Microsoft.HttpRepl.Fakes/NullPreferences.cs
+++ b/src/Microsoft.HttpRepl.Fakes/NullPreferences.cs
@@ -14,7 +14,7 @@ namespace Microsoft.HttpRepl.Fakes
 
         public AllowedColors GetColorValue(string preference, AllowedColors defaultValue = AllowedColors.None)
         {
-            return defaultValue;
+            return AllowedColors.None;
         }
 
         public int GetIntValue(string preference, int defaultValue = 0)

--- a/src/Microsoft.HttpRepl.Fakes/NullPreferences.cs
+++ b/src/Microsoft.HttpRepl.Fakes/NullPreferences.cs
@@ -12,17 +12,17 @@ namespace Microsoft.HttpRepl.Fakes
         public IReadOnlyDictionary<string, string> CurrentPreferences => null;
         public IReadOnlyDictionary<string, string> DefaultPreferences => null;
 
-        public AllowedColors GetColorValue(string preference, AllowedColors defaultValue = AllowedColors.None)
+        public AllowedColors GetColorValue(string preference, AllowedColors defaultValue = default)
         {
-            return AllowedColors.None;
+            return default;
         }
 
-        public int GetIntValue(string preference, int defaultValue = 0)
+        public int GetIntValue(string preference, int defaultValue = default)
         {
             return defaultValue;
         }
 
-        public string GetValue(string preference, string defaultValue = null)
+        public string GetValue(string preference, string defaultValue = default)
         {
             return defaultValue;
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/BaseIntegrationTest.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/BaseIntegrationTest.cs
@@ -52,10 +52,11 @@ namespace Microsoft.HttpRepl.IntegrationTests
 
         protected static async Task<string> RunTestScript(string scriptText, string baseAddress)
         {
-            var console = new LoggingConsoleManagerDecorator(new NullConsoleManager());
+            LoggingConsoleManagerDecorator console = new LoggingConsoleManagerDecorator(new NullConsoleManager());
+            NullPreferences preferences = new NullPreferences();
             using (var script = new TestScript(scriptText))
             {
-                await new Program().Start($"run {script.FilePath}".Split(' '), console);
+                await new Program().Start($"run {script.FilePath}".Split(' '), console, preferences);
             }
 
             string output = console.LoggedOutput;

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/GetCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/GetCommandTests.cs
@@ -92,7 +92,7 @@ get";
 Using swagger metadata from [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/~ cd api/invalidpath
-[33m[1mWarning: The '/api/invalidpath' endpoint is not present in the Swagger metadata[22m[39m
+Warning: The '/api/invalidpath' endpoint is not present in the Swagger metadata
 /api/invalidpath    []
 
 [BaseUrl]/api/invalidpath~ get

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/GetCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/GetCommandTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.HttpRepl.IntegrationTests.Commands
         }
 
         [Fact]
-        public async Task WithoutParameter_ShowsColorizedOutput()
+        public async Task WithoutParameter_ShowsCorrectOutput()
         {
             string scriptText = $@"set base {_serverConfig.BaseAddress}
 cd api/values
@@ -32,16 +32,16 @@ Using swagger metadata from [BaseUrl]/swagger/v1/swagger.json
 /api/values    [get|post]
 
 [BaseUrl]/api/values~ get
-[32m[1mHTTP[22m[39m[32m[1m/[22m[39m[32m[1m1.1[22m[39m [33m[1m200[22m[39m [33m[1mOK[22m[39m
+HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Date: [Date]
 Server: Kestrel
 Transfer-Encoding: chunked
 
-[36m[1m[[22m[39m
-  [32m""value1""[39m[33m[1m,[22m[39m
-  [32m""value2""[39m
-[36m[1m][22m[39m
+[
+  ""value1"",
+  ""value2""
+]
 
 
 [BaseUrl]/api/values~", null);
@@ -50,7 +50,7 @@ Transfer-Encoding: chunked
         }
 
         [Fact]
-        public async Task WithParameter_ShowsColorizedOutput()
+        public async Task WithParameter_ShowsCorrectOutput()
         {
             string scriptText = $@"set base {_serverConfig.BaseAddress}
 cd api/values
@@ -65,7 +65,7 @@ Using swagger metadata from [BaseUrl]/swagger/v1/swagger.json
 /api/values    [get|post]
 
 [BaseUrl]/api/values~ get 5
-[32m[1mHTTP[22m[39m[32m[1m/[22m[39m[32m[1m1.1[22m[39m [33m[1m200[22m[39m [33m[1mOK[22m[39m
+HTTP/1.1 200 OK
 Content-Type: text/plain; charset=utf-8
 Date: [Date]
 Server: Kestrel
@@ -96,7 +96,7 @@ Using swagger metadata from [BaseUrl]/swagger/v1/swagger.json
 /api/invalidpath    []
 
 [BaseUrl]/api/invalidpath~ get
-[32m[1mHTTP[22m[39m[32m[1m/[22m[39m[32m[1m1.1[22m[39m [33m[1m404[22m[39m [33m[1mNot Found[22m[39m
+HTTP/1.1 404 Not Found
 Content-Length: 0
 Date: [Date]
 Server: Kestrel
@@ -110,23 +110,23 @@ Server: Kestrel
         }
 
         [Fact]
-        public async Task WithNoSwaggerAndAbsoluteUrl_ShowsColorizedOutput()
+        public async Task WithNoSwaggerAndAbsoluteUrl_ShowsCorrectOutput()
         {
             string scriptText = $@"get {_serverConfig.BaseAddress}/api/values";
 
             string output = await RunTestScript(scriptText, _serverConfig.BaseAddress);
 
             string expected = NormalizeOutput(@"(Disconnected)~ get [BaseUrl]/api/values
-[32m[1mHTTP[22m[39m[32m[1m/[22m[39m[32m[1m1.1[22m[39m [33m[1m200[22m[39m [33m[1mOK[22m[39m
+HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Date: [Date]
 Server: Kestrel
 Transfer-Encoding: chunked
 
-[36m[1m[[22m[39m
-  [32m""value1""[39m[33m[1m,[22m[39m
-  [32m""value2""[39m
-[36m[1m][22m[39m
+[
+  ""value1"",
+  ""value2""
+]
 
 
 (Disconnected)~", null);

--- a/src/Microsoft.HttpRepl/Program.cs
+++ b/src/Microsoft.HttpRepl/Program.cs
@@ -21,12 +21,12 @@ namespace Microsoft.HttpRepl
     {
         public static async Task Main(string[] args)
         {
-            await new Program().Start(args, new ConsoleManager());
+            await new Program().Start(args);
         }
 
-        public async Task Start(string[] args, IConsoleManager consoleManager)
+        public async Task Start(string[] args, IConsoleManager consoleManager = null, IPreferences preferences = null)
         {           
-            ComposeDependencies(consoleManager, out HttpState state, out Shell shell, out IPreferences preferences);
+            ComposeDependencies(ref consoleManager, ref preferences, out HttpState state, out Shell shell);
 
             if (Console.IsOutputRedirected && !consoleManager.AllowOutputRedirection)
             {
@@ -73,11 +73,11 @@ namespace Microsoft.HttpRepl
             await result.ConfigureAwait(false);
         }
 
-        private static void ComposeDependencies(IConsoleManager consoleManager, out HttpState state, out Shell shell, out IPreferences preferences)
+        private static void ComposeDependencies(ref IConsoleManager consoleManager, ref IPreferences preferences, out HttpState state, out Shell shell)
         {
+            consoleManager = consoleManager ?? new ConsoleManager();
             IFileSystem fileSystem = new RealFileSystem();
-            IUserProfileDirectoryProvider userProfileDirectoryProvider = new UserProfileDirectoryProvider();
-            preferences = new Preferences.UserFolderPreferences(fileSystem, userProfileDirectoryProvider, CreateDefaultPreferences());
+            preferences = preferences ?? new UserFolderPreferences(fileSystem, new UserProfileDirectoryProvider(), CreateDefaultPreferences());
             HttpClient httpClient = new HttpClient();
             state = new HttpState(fileSystem, preferences, httpClient);
 

--- a/src/Microsoft.Repl/ConsoleHandling/AllowedColors.cs
+++ b/src/Microsoft.Repl/ConsoleHandling/AllowedColors.cs
@@ -5,26 +5,29 @@ using System;
 
 namespace Microsoft.Repl.ConsoleHandling
 {
+    // The values for the non-bold colors come from the ANSI escape sequences,
+    // specifically the SGR foreground codes, which can be referenced here:
+    // https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
     [Flags]
     public enum AllowedColors
     {
-        Black = 0x00,
+        None = 0x0,
+        Black = 0x1E,
         BoldBlack = Bold | Black,
-        Red = 0x01,
+        Red = 0x1F,
         BoldRed = Bold | Red,
-        Green = 0x02,
+        Green = 0x20,
         BoldGreen = Bold | Green,
-        Yellow = 0x03,
+        Yellow = 0x21,
         BoldYellow = Bold | Yellow,
-        Blue = 0x04,
+        Blue = 0x22,
         BoldBlue = Bold | Blue,
-        Magenta = 0x05,
+        Magenta = 0x23,
         BoldMagenta = Bold | Magenta,
-        Cyan = 0x06,
+        Cyan = 0x24,
         BoldCyan = Bold | Cyan,
-        White = 0x07,
+        White = 0x25,
         BoldWhite = White | Bold,
-        Bold = 0x100,
-        None = 0x99
+        Bold = 0x100
     }
 }

--- a/src/Microsoft.Repl/ConsoleHandling/AnsiColorExtensions.cs
+++ b/src/Microsoft.Repl/ConsoleHandling/AnsiColorExtensions.cs
@@ -5,48 +5,62 @@ namespace Microsoft.Repl.ConsoleHandling
 {
     public static class AnsiColorExtensions
     {
+        // For reference on these codes and values, see:
+        // https://en.wikipedia.org/wiki/ANSI_escape_code#Escape_sequences
+        private static readonly string _ansiControlSequenceIntroducer = "\x1B[";
+        private static readonly string _ansiSgrCode = "m";
+        private static readonly string _ansiSgrDefaultForegroundColor = $"{_ansiControlSequenceIntroducer}39{_ansiSgrCode}";
+        private static readonly string _ansiSgrNormalColorAndIntensity = $"{_ansiControlSequenceIntroducer}22{_ansiSgrCode}";
+        private static readonly string _ansiSgrBold = $"{_ansiControlSequenceIntroducer}1{_ansiSgrCode}";
+
         public static string Black(this string text)
         {
-            return "\x1B[30m" + text + "\x1B[39m";
+            return SetColorInternal(text, AllowedColors.Black);
         }
 
         public static string Red(this string text)
         {
-            return "\x1B[31m" + text + "\x1B[39m";
+            return SetColorInternal(text, AllowedColors.Red);
         }
         public static string Green(this string text)
         {
-            return "\x1B[32m" + text + "\x1B[39m";
+            return SetColorInternal(text, AllowedColors.Green);
         }
 
         public static string Yellow(this string text)
         {
-            return "\x1B[33m" + text + "\x1B[39m";
+            return SetColorInternal(text, AllowedColors.Yellow);
         }
 
         public static string Blue(this string text)
         {
-            return "\x1B[34m" + text + "\x1B[39m";
+            return SetColorInternal(text, AllowedColors.Blue);
         }
 
         public static string Magenta(this string text)
         {
-            return "\x1B[35m" + text + "\x1B[39m";
+            return SetColorInternal(text, AllowedColors.Magenta);
         }
 
         public static string Cyan(this string text)
         {
-            return "\x1B[36m" + text + "\x1B[39m";
+            return SetColorInternal(text, AllowedColors.Cyan);
         }
 
         public static string White(this string text)
         {
-            return "\x1B[37m" + text + "\x1B[39m";
+            return SetColorInternal(text, AllowedColors.White);
         }
 
         public static string Bold(this string text)
         {
-            return "\x1B[1m" + text + "\x1B[22m";
+            return $"{_ansiSgrBold}{text}{_ansiSgrNormalColorAndIntensity}";
+        }
+
+        private static string SetColorInternal(string text, AllowedColors color)
+        {
+            int sgrParameter = (int)color;
+            return $"{_ansiControlSequenceIntroducer}{sgrParameter}{_ansiSgrCode}{text}{_ansiSgrDefaultForegroundColor}";
         }
 
         public static string SetColor(this string text, AllowedColors color)
@@ -60,21 +74,14 @@ namespace Microsoft.Repl.ConsoleHandling
             switch (color)
             {
                 case AllowedColors.Black:
-                    return text.Black();
                 case AllowedColors.Red:
-                    return text.Red();
                 case AllowedColors.Green:
-                    return text.Green();
                 case AllowedColors.Yellow:
-                    return text.Yellow();
                 case AllowedColors.Blue:
-                    return text.Blue();
                 case AllowedColors.Magenta:
-                    return text.Magenta();
                 case AllowedColors.Cyan:
-                    return text.Cyan();
                 case AllowedColors.White:
-                    return text.White();
+                    return SetColorInternal(text, color);
                 default:
                     return text;
             }


### PR DESCRIPTION
This PR follows on from the discussion on https://github.com/aspnet/HttpRepl/pull/106#discussion_r306454633.

It cleans up the integration test output substantially by allowing a `NullPreferences` object to be used.

Unfortunately, due to https://github.com/aspnet/HttpRepl/blob/6ffda0536534c4c9311b0a82eb29402af371817e/src/Microsoft.HttpRepl/HttpState.cs#L21 and https://github.com/aspnet/HttpRepl/blob/6ffda0536534c4c9311b0a82eb29402af371817e/src/Microsoft.HttpRepl/HttpState.cs#L23 the warning and error colors were not blanked out as part of the `NullPreferences` object. So I had to make a change there as well to always return `AllowedColors.None` rather than always returning the passed-in default. It doesn't appear that this change causes any other unintended consequences, but I wanted to call it out just in case.