### PR TITLE
Convert Microsoft.Repl to a .NET Standard library and add pack

### DIFF
--- a/build/PackageVersions.targets
+++ b/build/PackageVersions.targets
@@ -10,5 +10,7 @@
     <PackageReference Update="Newtonsoft.Json" Version="12.0.2" PrivateAssets="All" />
     <PackageReference Update="Swashbuckle.AspNetCore" Version="5.0.0-rc2" PrivateAssets="All" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
+    <PackageReference Update="System.Diagnostics.Process" Version="4.3.0" />
+    <PackageReference Update="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Repl/Commanding/CommandWithStructuredInputBase.cs
+++ b/src/Microsoft.Repl/Commanding/CommandWithStructuredInputBase.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Repl.Commanding
                 return null;
             }
 
-            if (normalCompletionString.StartsWith(InputSpec.OptionPreamble))
+            if (normalCompletionString.StartsWith(InputSpec.OptionPreamble.ToString()))
             {
                 return GetOptionCompletions(commandInput, normalCompletionString);
             }

--- a/src/Microsoft.Repl/Commanding/DefaultCommandInput.cs
+++ b/src/Microsoft.Repl/Commanding/DefaultCommandInput.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Repl.Commanding
             for (int i = spec.CommandName.Count; i < parseResult.Sections.Count; ++i)
             {
                 //If we're not looking at an option name
-                if (!parseResult.Sections[i].StartsWith(spec.OptionPreamble) || parseResult.IsQuotedSection(i))
+                if (!parseResult.Sections[i].StartsWith(spec.OptionPreamble.ToString()) || parseResult.IsQuotedSection(i))
                 {
                     if (currentOption is null)
                     {

--- a/src/Microsoft.Repl/Input/KeyHandlers.cs
+++ b/src/Microsoft.Repl/Input/KeyHandlers.cs
@@ -68,50 +68,17 @@ namespace Microsoft.Repl.Input
             inputManager.RegisterKeyHandler(ConsoleKey.F23, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.F24, Unhandled);
 
-            inputManager.RegisterKeyHandler(ConsoleKey.Applications, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.Attention, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.BrowserBack, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.BrowserFavorites, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.BrowserForward, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.BrowserHome, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.BrowserRefresh, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.BrowserSearch, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.BrowserStop, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.Clear, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.CrSel, Unhandled);
-
-            inputManager.RegisterKeyHandler(ConsoleKey.EraseEndOfFile, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.Execute, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.ExSel, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.Help, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.LaunchApp1, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.LaunchApp2, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.LaunchMail, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.LaunchMediaSelect, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.LeftWindows, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.MediaNext, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.MediaPlay, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.MediaPrevious, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.MediaStop, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.NoName, Unhandled);
-
-            inputManager.RegisterKeyHandler(ConsoleKey.Pa1, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.Packet, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.PageDown, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.PageUp, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.Pause, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.Play, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.Print, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.PrintScreen, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.Process, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.RightWindows, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.Select, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.Separator, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.Sleep, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.VolumeDown, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.VolumeMute, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.VolumeUp, Unhandled);
-            inputManager.RegisterKeyHandler(ConsoleKey.Zoom, Unhandled);
         }
 
         private static Task End(ConsoleKeyInfo keyInfo, IShellState state, CancellationToken cancellationToken)

--- a/src/Microsoft.Repl/Microsoft.Repl.csproj
+++ b/src/Microsoft.Repl/Microsoft.Repl.csproj
@@ -1,10 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <Description>A framework for creating REPLs in .NET Standard.</Description>
     <PackageTags>dotnet;repl</PackageTags>
-    <IsPackable>false</IsPackable>
+    <PackageId>Microsoft.Repl</PackageId>
+    <PackageIconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
+    
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Repl/Microsoft.Repl.csproj
+++ b/src/Microsoft.Repl/Microsoft.Repl.csproj
@@ -1,10 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
-    <Description>A framework for creating REPLs in .NET Core.</Description>
+    <TargetFramework>netstandard1.3</TargetFramework>
+    <Description>A framework for creating REPLs in .NET Standard.</Description>
     <PackageTags>dotnet;repl</PackageTags>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Diagnostics.Process" />
+    <PackageReference Include="System.Threading.Thread" />
+  </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Repl/Suggestions/FileSystemCompletion.cs
+++ b/src/Microsoft.Repl/Suggestions/FileSystemCompletion.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Repl.Suggestions
     {
         public static IEnumerable<string> GetCompletions(string prefix)
         {
-            if (prefix.StartsWith('\"'))
+            if (prefix.StartsWith("\""))
             {
                 prefix = prefix.Substring(1);
 


### PR DESCRIPTION
In support of recent interest in the underlying Microsoft.Repl library, this PR converts it to a .NET Standard 1.3 library (as opposed to .net core 2.1 and 3.0 libraries) to expand its reach, and set it to generate a nuget package.

I picked 1.3 based on the chart [here](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support) and the fact that .NET Framework 4.6 is the lowest version in mainstream support (I think) listed in that chart. I'm open to suggestions on a different target, though.

The two new package refs were just because of things that weren't natively supported in netstandard1.3, not because of any changes in the library.

I left out the `<PackageProjectUrl>` in `Microsoft.Repl.csproj` since we don't have documentation or a website specifically for the Repl and it'll just default to the github url if we leave it out (i think). Let me know if that's not correct.