### PR TITLE
Fix the exception "NullReferenceException" throw by set swagger command.

### DIFF
--- a/src/Microsoft.HttpRepl.Tests/Commands/SetSwaggerCommandTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/SetSwaggerCommandTests.cs
@@ -332,6 +332,51 @@ namespace Microsoft.HttpRepl.Tests.Commands
             Assert.Equal("Values", childDirectoryNames.ElementAt(1));
         }
 
+        [Fact]
+        public async Task ExecuteAsync_WithChildDirectories_SetsHttpStateSwaggerStructureWithChildDirectorStuctureInfoWhenSchemaPropertiesIsNull()
+        {
+            string response = @"{
+  ""swagger"": ""2.0"",
+  ""paths"": {
+    ""/api/Values"": {
+      ""post"": {
+        ""tags"": [ ""Values"" ],
+        ""operationId"": ""Post"",
+        ""consumes"": [ ""application/json-patch+json"", ""application/json"", ""text/json"", ""application/*+json"" ],
+        ""produces"": [],
+        ""parameters"": [
+          {
+            ""name"": ""value"",
+            ""in"": ""body"",
+            ""required"": false,
+            ""schema"": {
+              ""type"":""object""
+            }
+          }
+        ],
+        ""responses"": { ""200"": { ""description"": ""Success"" } }
+      }
+    }
+  }
+}";
+            string baseAddress = "http://localhost:5050/somePath";
+            string parseResultSections = "set swagger " + baseAddress;
+            IDirectoryStructure directoryStructure = await GetDirectoryStructure(response, parseResultSections, baseAddress).ConfigureAwait(false);
+            List<string> directoryNames = directoryStructure.DirectoryNames.ToList();
+            string expectedDirectoryName = "api";
+
+            Assert.Single(directoryNames);
+            Assert.Equal(expectedDirectoryName, directoryNames.First());
+
+            IDirectoryStructure childDirectoryStructure = directoryStructure.GetChildDirectory(expectedDirectoryName);
+            Assert.NotNull(childDirectoryStructure);
+
+            List<string> childDirectoryNames = childDirectoryStructure.DirectoryNames.ToList();
+
+            Assert.Single(childDirectoryNames);
+            Assert.Equal("Values", childDirectoryNames.First());
+        }
+
         private async Task<IDirectoryStructure> GetDirectoryStructure(string response, string parseResultSections, string baseAddress)
         {
             MockedShellState shellState = new MockedShellState();

--- a/src/Microsoft.HttpRepl/Commands/SetSwaggerCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/SetSwaggerCommand.cs
@@ -162,13 +162,17 @@ namespace Microsoft.HttpRepl.Commands
 
                     return container;
                 case "OBJECT":
-                    JObject obj = new JObject();
-                    foreach (KeyValuePair<string, Schema> property in schema.Properties)
+                    if (schema.Properties != null)
                     {
-                        JToken data = GenerateData(property.Value) ?? "";
-                        obj[property.Key] = data;
+                        JObject obj = new JObject();
+                        foreach (KeyValuePair<string, Schema> property in schema.Properties)
+                        {
+                            JToken data = GenerateData(property.Value) ?? "";
+                            obj[property.Key] = data;
+                        }
+                        return obj;
                     }
-                    return obj;
+                    return null;
             }
 
             return null;
@@ -179,7 +183,7 @@ namespace Microsoft.HttpRepl.Commands
             var resp = await client.GetAsync(uri).ConfigureAwait(false);
             resp.EnsureSuccessStatusCode();
             string responseString = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
-            JsonSerializer serializer = new JsonSerializer{ PreserveReferencesHandling = PreserveReferencesHandling.All };
+            JsonSerializer serializer = new JsonSerializer { PreserveReferencesHandling = PreserveReferencesHandling.All };
             JObject responseObject = (JObject)serializer.Deserialize(new StringReader(responseString), typeof(JObject));
             EndpointMetadataReader reader = new EndpointMetadataReader();
             responseObject = await PointerUtil.ResolvePointersAsync(uri, responseObject, client).ConfigureAwait(false) as JObject;


### PR DESCRIPTION
- This issue is cause by `Schema.Properties` is null,  when this exception occur, it will set the `Structure` to null.