### PR TITLE
Check for being in bounds of commandName before accessing item

### DIFF
--- a/src/Microsoft.Repl/Commanding/CommandWithStructuredInputBase.cs
+++ b/src/Microsoft.Repl/Commanding/CommandWithStructuredInputBase.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Repl.Commanding
 
         public string GetHelpDetails(IShellState shellState, TProgramState programState, TParseResult parseResult)
         {
-            if (!DefaultCommandInput<TParseResult>.TryProcess(InputSpec, parseResult, out DefaultCommandInput<TParseResult> commandInput, out IReadOnlyList<CommandInputProcessingIssue> processingIssues) 
+            if (!DefaultCommandInput<TParseResult>.TryProcess(InputSpec, parseResult, out DefaultCommandInput<TParseResult> commandInput, out IReadOnlyList<CommandInputProcessingIssue> processingIssues)
                 && processingIssues.Any(x => x.Kind == CommandInputProcessingIssueKind.CommandMismatch))
             {
                 //If this is the right command, just not the right syntax, report the usage errors
@@ -65,7 +65,7 @@ namespace Microsoft.Repl.Commanding
                     return null;
                 }
 
-                if (commandName[parseResult.SelectedSection].StartsWith(normalCompletionString, StringComparison.OrdinalIgnoreCase))
+                if (parseResult.SelectedSection < commandName.Count && commandName[parseResult.SelectedSection].StartsWith(normalCompletionString, StringComparison.OrdinalIgnoreCase))
                 {
                     return new[] {commandName[parseResult.SelectedSection]};
                 }


### PR DESCRIPTION
If you type in `dir` and then hit tab, HttpRepl will crash.
It was happening as it was accessing an invalid index (1) in the the `commandName` list when the count was 1.
This adds a quick check to see if the `SelectedSection` is in bounds of the list before accessing the element.