### PR TITLE
README.md - Update Installation Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The HTTP Read-Eval-Print Loop (REPL) is:
 To install the HTTP REPL, run the following command:
 
 ```
-dotnet tool install -g Microsoft.dotnet-httprepl --version 3.0.0-*
+dotnet tool install -g Microsoft.dotnet-httprepl "--version 3.0.0-*"
 ```
 
 A [.NET Core Global Tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools#install-a-global-tool) is installed from the [Microsoft.dotnet-httprepl](https://www.nuget.org/packages/Microsoft.dotnet-httprepl) NuGet package.


### PR DESCRIPTION
- Use quotes for the version parameter.
  - Without the quotes the install command will fail when running in ZSH with the following Error: `zsh: no matches found: 3.0.0*`