### PR TITLE
Allow the user agent header to be set via a preference

### DIFF
--- a/src/Microsoft.HttpRepl/HttpState.cs
+++ b/src/Microsoft.HttpRepl/HttpState.cs
@@ -42,7 +42,7 @@ namespace Microsoft.HttpRepl
             PathSections = new Stack<string>();
             Headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase)
             {
-                { "User-Agent", new[] { "HTTP-REPL" } }
+                { "User-Agent", new[] { _preferences.GetValue(WellKnownPreference.HttpClientUserAgent, "HTTP-REPL") } }
             };
         }
 

--- a/src/Microsoft.HttpRepl/Preferences/WellKnownPreference.cs
+++ b/src/Microsoft.HttpRepl/Preferences/WellKnownPreference.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using System.Security;
 
 namespace Microsoft.HttpRepl.Preferences
 {
@@ -171,5 +172,7 @@ namespace Microsoft.HttpRepl.Preferences
         public static string SwaggerRequeryBehavior { get; } = "swagger.requery";
 
         public static string UseDefaultCredentials { get; } = "httpClient.useDefaultCredentials";
+
+        public static string HttpClientUserAgent { get; } = "httpClient.userAgent";
     }
 }


### PR DESCRIPTION
This resolves #123. 

Currently, since there's no mechanism to notify other parts of the system when a preference changes, this will require a restart. I put in #165 to address that in the future for this and other settings that it may be useful for.